### PR TITLE
Pin terraform-aws-modules/iam to ~> 5.0 to fix broken module path

### DIFF
--- a/terraform/modules/aws/cluster-addons-layer/main.tf
+++ b/terraform/modules/aws/cluster-addons-layer/main.tf
@@ -1,5 +1,6 @@
 module "aws_load_balancer_controller_irsa_role" {
-  source = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "~> 5.0"
 
   role_name                              = "${var.environment_name}_eks_lb"
   attach_load_balancer_controller_policy = true
@@ -104,7 +105,8 @@ resource "helm_release" "external-dns" {
 }
 
 module "external_dns_irsa_role" {
-  source = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "~> 5.0"
 
   role_name                  = "${var.environment_name}_eks_external_dns"
   attach_external_dns_policy = true


### PR DESCRIPTION
v6.x renamed iam-role-for-service-accounts-eks; without a version pin all environments were pulling the latest and hitting a missing directory error.