### PR TITLE
Migrate kubernetes_service_account to kubernetes_service_account_v1

### DIFF
--- a/terraform/modules/aws/cluster-addons-layer/main.tf
+++ b/terraform/modules/aws/cluster-addons-layer/main.tf
@@ -153,13 +153,3 @@ resource "helm_release" "metrics-server" {
   chart      = "metrics-server"
   version    = "3.8.3"
 }
-
-moved {
-  from = kubernetes_service_account.aws_load_balancer_controller_service_account
-  to   = kubernetes_service_account_v1.aws_load_balancer_controller_service_account
-}
-
-moved {
-  from = kubernetes_service_account.external_dns_service_account
-  to   = kubernetes_service_account_v1.external_dns_service_account
-}

--- a/terraform/modules/aws/cluster-addons-layer/main.tf
+++ b/terraform/modules/aws/cluster-addons-layer/main.tf
@@ -13,7 +13,7 @@ module "aws_load_balancer_controller_irsa_role" {
   }
 }
 
-resource "kubernetes_service_account" "aws_load_balancer_controller_service_account" {
+resource "kubernetes_service_account_v1" "aws_load_balancer_controller_service_account" {
   metadata {
     name      = "aws-load-balancer-controller"
     namespace = "kube-system"
@@ -32,7 +32,7 @@ resource "helm_release" "aws_load_balancer_controller" {
   atomic = true
   chart  = "aws-load-balancer-controller"
   depends_on = [
-    kubernetes_service_account.aws_load_balancer_controller_service_account
+    kubernetes_service_account_v1.aws_load_balancer_controller_service_account
   ]
   name       = "aws-load-balancer-controller"
   namespace  = "kube-system"
@@ -50,7 +50,7 @@ resource "helm_release" "aws_load_balancer_controller" {
 
   set {
     name  = "serviceAccount.name"
-    value = kubernetes_service_account.aws_load_balancer_controller_service_account.metadata[0].name
+    value = kubernetes_service_account_v1.aws_load_balancer_controller_service_account.metadata[0].name
   }
 
   set {
@@ -64,7 +64,7 @@ resource "helm_release" "aws_load_balancer_controller" {
 resource "kubernetes_secret_v1" "aws_load_balancer_controller_service_account" {
   metadata {
     annotations = {
-      "kubernetes.io/service-account.name" = kubernetes_service_account.aws_load_balancer_controller_service_account.metadata[0].name
+      "kubernetes.io/service-account.name" = kubernetes_service_account_v1.aws_load_balancer_controller_service_account.metadata[0].name
     }
     name      = "aws-load-balancer-controller-token"
     namespace = "kube-system"
@@ -76,7 +76,7 @@ resource "kubernetes_secret_v1" "aws_load_balancer_controller_service_account" {
 
 resource "helm_release" "external-dns" {
   depends_on = [
-    kubernetes_service_account.external_dns_service_account
+    kubernetes_service_account_v1.external_dns_service_account
   ]
   name       = "external-dns"
   repository = "oci://registry-1.docker.io/bitnamicharts"
@@ -120,7 +120,7 @@ module "external_dns_irsa_role" {
   }
 }
 
-resource "kubernetes_service_account" "external_dns_service_account" {
+resource "kubernetes_service_account_v1" "external_dns_service_account" {
   metadata {
     name      = "external-dns"
     namespace = "kube-system"
@@ -137,7 +137,7 @@ resource "kubernetes_service_account" "external_dns_service_account" {
 resource "kubernetes_secret_v1" "external_dns_service_account" {
   metadata {
     annotations = {
-      "kubernetes.io/service-account.name" = kubernetes_service_account.external_dns_service_account.metadata[0].name
+      "kubernetes.io/service-account.name" = kubernetes_service_account_v1.external_dns_service_account.metadata[0].name
     }
     name      = "external-dns-token"
     namespace = "kube-system"
@@ -152,4 +152,14 @@ resource "helm_release" "metrics-server" {
   repository = "https://kubernetes-sigs.github.io/metrics-server/"
   chart      = "metrics-server"
   version    = "3.8.3"
+}
+
+moved {
+  from = kubernetes_service_account.aws_load_balancer_controller_service_account
+  to   = kubernetes_service_account_v1.aws_load_balancer_controller_service_account
+}
+
+moved {
+  from = kubernetes_service_account.external_dns_service_account
+  to   = kubernetes_service_account_v1.external_dns_service_account
 }


### PR DESCRIPTION
Replaces deprecated kubernetes_service_account resources with the v1 variant for ALB controller and external-dns. Adds moved blocks to migrate existing state without destroying live resources.