### PR TITLE
Override external-dns image registry to AWS ECR Public

### DIFF
--- a/terraform/modules/aws/cluster-addons-layer/main.tf
+++ b/terraform/modules/aws/cluster-addons-layer/main.tf
@@ -95,6 +95,11 @@ resource "helm_release" "external-dns" {
   }
 
   set {
+    name  = "image.registry"
+    value = "public.ecr.aws"
+  }
+
+  set {
     name  = "serviceAccount.create"
     value = "false"
   }


### PR DESCRIPTION
Bitnami no longer provides free pinned image tags on Docker Hub (Broadcom acquisition). ECR Public mirrors Bitnami images at public.ecr.aws without auth or rate limits from within AWS.