### PR TITLE
Allow ECR image registry override in external-dns Helm release

### DIFF
--- a/terraform/modules/aws/cluster-addons-layer/main.tf
+++ b/terraform/modules/aws/cluster-addons-layer/main.tf
@@ -100,6 +100,11 @@ resource "helm_release" "external-dns" {
   }
 
   set {
+    name  = "global.security.allowInsecureImages"
+    value = "true"
+  }
+
+  set {
     name  = "serviceAccount.create"
     value = "false"
   }


### PR DESCRIPTION
Sets global.security.allowInsecureImages=true to bypass Bitnami's image verification check when using the ECR Public registry override.