### PR TITLE
Fix ambiguous aws_lb_target_group lookup returning 2 results

### DIFF
--- a/terraform/modules/aws/cluster-addons-layer/cloudwatch_alarms.tf
+++ b/terraform/modules/aws/cluster-addons-layer/cloudwatch_alarms.tf
@@ -6,6 +6,7 @@ data "aws_lb_target_group" "app" {
   tags = {
     "kubernetes.io/ingress-name" = "automation-calculator"
     "kubernetes.io/namespace"    = "automation-calculator"
+    "kubernetes.io/service-name" = "automation-calculator"
   }
 }
 


### PR DESCRIPTION
The ingress has two backends (automation-calculator and redirect-www), so the ALB controller tags both target groups with the same ingress-name and namespace tags. Adding the service-name tag narrows the lookup to just the main app target group.