### PR TITLE
Move remote_state_consumer_ids to tfe_workspace_settings resource

### DIFF
--- a/terraform/modules/tf_cloud/tf_cloud_workspaces/main.tf
+++ b/terraform/modules/tf_cloud/tf_cloud_workspaces/main.tf
@@ -1,15 +1,19 @@
 resource "tfe_workspace" "base_cluster_tfe_workspace" {
-  name                      = "ac_app_${var.environment_name}_base_cluster_layer"
-  organization              = var.tf_cloud_organization_name
-  remote_state_consumer_ids = [tfe_workspace.cluster_addons_tfe_workspace.id]
-  tag_names                 = local.shared_workspace_tags
-  terraform_version         = var.tfe_workspace_tf_version
-  trigger_prefixes          = concat([var.base_cluster_layer_working_directory], var.base_cluster_layer_module_directories)
+  name              = "ac_app_${var.environment_name}_base_cluster_layer"
+  organization      = var.tf_cloud_organization_name
+  tag_names         = local.shared_workspace_tags
+  terraform_version = var.tfe_workspace_tf_version
+  trigger_prefixes  = concat([var.base_cluster_layer_working_directory], var.base_cluster_layer_module_directories)
   vcs_repo {
     identifier     = var.tf_cloud_workspace_vcs_repo_identifier
     oauth_token_id = var.tfe_oauth_client_token_id
   }
   working_directory = var.base_cluster_layer_working_directory
+}
+
+resource "tfe_workspace_settings" "base_cluster_tfe_workspace" {
+  workspace_id              = tfe_workspace.base_cluster_tfe_workspace.id
+  remote_state_consumer_ids = [tfe_workspace.cluster_addons_tfe_workspace.id]
 }
 
 resource "tfe_workspace" "cluster_addons_tfe_workspace" {


### PR DESCRIPTION
The tfe_workspace attribute remote_state_consumer_ids is deprecated and will be removed in a future TFE provider release. Moving it to the dedicated tfe_workspace_settings resource as recommended.