### PR TITLE
Add auto_apply variable to tf_cloud_workspaces module (#245)

### DIFF
--- a/terraform/env/development/tf_cloud/main.tf
+++ b/terraform/env/development/tf_cloud/main.tf
@@ -11,6 +11,7 @@ resource "tfe_oauth_client" "github" {
 }
 
 module "tf_cloud_workspaces" {
+  auto_apply                              = var.auto_apply
   base_cluster_layer_working_directory    = var.base_cluster_layer_working_directory
   cluster_addons_layer_module_directories = var.cluster_addons_layer_module_directories
   cluster_addons_layer_working_directory  = var.cluster_addons_layer_working_directory

--- a/terraform/env/development/tf_cloud/terraform.tfvars
+++ b/terraform/env/development/tf_cloud/terraform.tfvars
@@ -1,3 +1,4 @@
+auto_apply                              = true
 base_cluster_layer_working_directory    = "terraform/env/development/aws/us-west-1/base-cluster-layer"
 cluster_addons_layer_working_directory  = "terraform/env/development/aws/us-west-1/cluster-addons-layer"
 environment_name                        = "development"

--- a/terraform/env/development/tf_cloud/variables.tf
+++ b/terraform/env/development/tf_cloud/variables.tf
@@ -48,3 +48,9 @@ variable "enable_cluster_addons_run_trigger" {
   type        = bool
   default     = true
 }
+
+variable "auto_apply" {
+  description = "When true, automatically applies successful plans triggered via the API, UI, or VCS. Should be false for production."
+  type        = bool
+  default     = false
+}

--- a/terraform/env/production/tf_cloud/main.tf
+++ b/terraform/env/production/tf_cloud/main.tf
@@ -11,6 +11,7 @@ resource "tfe_oauth_client" "github" {
 }
 
 module "tf_cloud_workspaces" {
+  auto_apply                             = var.auto_apply
   base_cluster_layer_working_directory   = var.base_cluster_layer_working_directory
   cluster_addons_layer_working_directory = var.cluster_addons_layer_working_directory
   enable_cluster_addons_run_trigger      = var.enable_cluster_addons_run_trigger

--- a/terraform/env/production/tf_cloud/variables.tf
+++ b/terraform/env/production/tf_cloud/variables.tf
@@ -36,3 +36,9 @@ variable "enable_cluster_addons_run_trigger" {
   type        = bool
   default     = true
 }
+
+variable "auto_apply" {
+  description = "When true, automatically applies successful plans triggered via the API, UI, or VCS. Should be false for production."
+  type        = bool
+  default     = false
+}

--- a/terraform/env/staging/tf_cloud/main.tf
+++ b/terraform/env/staging/tf_cloud/main.tf
@@ -11,6 +11,7 @@ resource "tfe_oauth_client" "github" {
 }
 
 module "tf_cloud_workspaces" {
+  auto_apply                             = var.auto_apply
   base_cluster_layer_working_directory   = var.base_cluster_layer_working_directory
   cluster_addons_layer_working_directory = var.cluster_addons_layer_working_directory
   enable_cluster_addons_run_trigger      = var.enable_cluster_addons_run_trigger

--- a/terraform/env/staging/tf_cloud/terraform.tfvars
+++ b/terraform/env/staging/tf_cloud/terraform.tfvars
@@ -1,3 +1,4 @@
+auto_apply                             = true
 base_cluster_layer_working_directory   = "terraform/env/staging/aws/us-west-1/base-cluster-layer"
 cluster_addons_layer_working_directory = "terraform/env/staging/aws/us-west-1/cluster-addons-layer"
 environment_name                       = "staging"

--- a/terraform/env/staging/tf_cloud/variables.tf
+++ b/terraform/env/staging/tf_cloud/variables.tf
@@ -36,3 +36,9 @@ variable "enable_cluster_addons_run_trigger" {
   type        = bool
   default     = true
 }
+
+variable "auto_apply" {
+  description = "When true, automatically applies successful plans triggered via the API, UI, or VCS. Should be false for production."
+  type        = bool
+  default     = false
+}

--- a/terraform/modules/tf_cloud/tf_cloud_workspaces/main.tf
+++ b/terraform/modules/tf_cloud/tf_cloud_workspaces/main.tf
@@ -1,6 +1,7 @@
 resource "tfe_workspace" "base_cluster_tfe_workspace" {
   name              = "ac_app_${var.environment_name}_base_cluster_layer"
   organization      = var.tf_cloud_organization_name
+  auto_apply        = var.auto_apply
   tag_names         = local.shared_workspace_tags
   terraform_version = var.tfe_workspace_tf_version
   trigger_prefixes  = concat([var.base_cluster_layer_working_directory], var.base_cluster_layer_module_directories)
@@ -25,6 +26,7 @@ resource "tfe_run_trigger" "cluster_addons_run_trigger" {
 resource "tfe_workspace" "cluster_addons_tfe_workspace" {
   name              = "ac_app_${var.environment_name}_cluster_addons_layer"
   organization      = var.tf_cloud_organization_name
+  auto_apply        = var.auto_apply
   tag_names         = local.shared_workspace_tags
   terraform_version = var.tfe_workspace_tf_version
   trigger_prefixes  = concat([var.cluster_addons_layer_working_directory], var.cluster_addons_layer_module_directories)

--- a/terraform/modules/tf_cloud/tf_cloud_workspaces/variables.tf
+++ b/terraform/modules/tf_cloud/tf_cloud_workspaces/variables.tf
@@ -66,3 +66,9 @@ variable "enable_cluster_addons_run_trigger" {
   type        = bool
   default     = true
 }
+
+variable "auto_apply" {
+  description = "When true, automatically applies successful plans triggered via the API, UI, or VCS. Should be false for production."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
Adds an auto_apply variable to both workspaces in the tf_cloud_workspaces module, enabling automatic plan application for API, UI, and VCS-triggered runs. Enabled via tfvars for development and staging; production keeps the default of false to require manual approval.