### PR TITLE
Add configurable tf version variable to tf_cloud env configs and pin …

### DIFF
--- a/terraform/env/development/tf_cloud/main.tf
+++ b/terraform/env/development/tf_cloud/main.tf
@@ -22,4 +22,5 @@ module "tf_cloud_workspaces" {
   tf_cloud_organization_name              = var.tf_cloud_organization_name
   tf_cloud_workspace_vcs_repo_identifier  = var.tf_cloud_workspace_vcs_repo_identifier
   tfe_oauth_client_token_id               = tfe_oauth_client.github.oauth_token_id
+  tfe_workspace_tf_version                = var.tfe_workspace_tf_version
 }

--- a/terraform/env/development/tf_cloud/terraform.tfvars
+++ b/terraform/env/development/tf_cloud/terraform.tfvars
@@ -3,3 +3,4 @@ base_cluster_layer_working_directory    = "terraform/env/development/aws/us-west
 cluster_addons_layer_working_directory  = "terraform/env/development/aws/us-west-1/cluster-addons-layer"
 environment_name                        = "development"
 cluster_addons_layer_module_directories = []
+tfe_workspace_tf_version                = "1.3.7"

--- a/terraform/env/development/tf_cloud/variables.tf
+++ b/terraform/env/development/tf_cloud/variables.tf
@@ -54,3 +54,9 @@ variable "auto_apply" {
   type        = bool
   default     = false
 }
+
+variable "tfe_workspace_tf_version" {
+  description = "Allows for version pinning of tfe workspaces that have been created, because otherwise TF Cloud just chooses the latest one."
+  type        = string
+  default     = "1.3.7"
+}

--- a/terraform/env/production/tf_cloud/main.tf
+++ b/terraform/env/production/tf_cloud/main.tf
@@ -20,4 +20,5 @@ module "tf_cloud_workspaces" {
   tf_cloud_organization_name             = var.tf_cloud_organization_name
   tf_cloud_workspace_vcs_repo_identifier = var.tf_cloud_workspace_vcs_repo_identifier
   tfe_oauth_client_token_id              = tfe_oauth_client.github.oauth_token_id
+  tfe_workspace_tf_version               = var.tfe_workspace_tf_version
 }

--- a/terraform/env/production/tf_cloud/terraform.tfvars
+++ b/terraform/env/production/tf_cloud/terraform.tfvars
@@ -1,3 +1,4 @@
 base_cluster_layer_working_directory   = "terraform/env/production/aws/us-west-1/base-cluster-layer"
 cluster_addons_layer_working_directory = "terraform/env/production/aws/us-west-1/cluster-addons-layer"
 environment_name                       = "production"
+tfe_workspace_tf_version               = "1.3.7"

--- a/terraform/env/production/tf_cloud/variables.tf
+++ b/terraform/env/production/tf_cloud/variables.tf
@@ -42,3 +42,9 @@ variable "auto_apply" {
   type        = bool
   default     = false
 }
+
+variable "tfe_workspace_tf_version" {
+  description = "Allows for version pinning of tfe workspaces that have been created, because otherwise TF Cloud just chooses the latest one."
+  type        = string
+  default     = "1.3.7"
+}

--- a/terraform/env/staging/tf_cloud/main.tf
+++ b/terraform/env/staging/tf_cloud/main.tf
@@ -20,4 +20,5 @@ module "tf_cloud_workspaces" {
   tf_cloud_organization_name             = var.tf_cloud_organization_name
   tf_cloud_workspace_vcs_repo_identifier = var.tf_cloud_workspace_vcs_repo_identifier
   tfe_oauth_client_token_id              = tfe_oauth_client.github.oauth_token_id
+  tfe_workspace_tf_version               = var.tfe_workspace_tf_version
 }

--- a/terraform/env/staging/tf_cloud/terraform.tfvars
+++ b/terraform/env/staging/tf_cloud/terraform.tfvars
@@ -2,3 +2,4 @@ auto_apply                             = true
 base_cluster_layer_working_directory   = "terraform/env/staging/aws/us-west-1/base-cluster-layer"
 cluster_addons_layer_working_directory = "terraform/env/staging/aws/us-west-1/cluster-addons-layer"
 environment_name                       = "staging"
+tfe_workspace_tf_version               = "1.3.7"

--- a/terraform/env/staging/tf_cloud/variables.tf
+++ b/terraform/env/staging/tf_cloud/variables.tf
@@ -42,3 +42,9 @@ variable "auto_apply" {
   type        = bool
   default     = false
 }
+
+variable "tfe_workspace_tf_version" {
+  description = "Allows for version pinning of tfe workspaces that have been created, because otherwise TF Cloud just chooses the latest one."
+  type        = string
+  default     = "1.3.7"
+}


### PR DESCRIPTION
…to 1.3.7

Exposes tfe_workspace_tf_version through each env's variables.tf and module call so workspaces don't drift to TF Cloud's latest default version.