### PR TITLE
Remove www_redirector Route53 record managed by external-dns

### DIFF
--- a/terraform/modules/aws/main_rails_app/main.tf
+++ b/terraform/modules/aws/main_rails_app/main.tf
@@ -149,13 +149,3 @@ resource "aws_route53_record" "automation_calculator_app_cert_validation" {
   zone_id         = data.aws_route53_zone.automation_calculator_app.zone_id
 }
 
-resource "aws_route53_record" "automation_calculator_app_www_redirector" {
-  alias {
-    evaluate_target_health = false
-    name                   = var.automation_calculator_app_host
-    zone_id                = data.aws_route53_zone.automation_calculator_app.zone_id
-  }
-  name    = local.www_redirect_name
-  type    = "A"
-  zone_id = data.aws_route53_zone.automation_calculator_app.zone_id
-}


### PR DESCRIPTION
The ingress template registers www.<host> as a host, so external-dns automatically creates and owns the www Route53 alias pointing to the ALB. The Terraform record was fighting external-dns and losing on every apply (perpetual diff). The ALB already handles the HTTP 301 www→non-www redirect via the redirect-www action annotation, so no Terraform record is needed.