### PR TITLE
Add run trigger from base cluster to cluster addons workspace (#244)

### DIFF
--- a/terraform/env/development/tf_cloud/main.tf
+++ b/terraform/env/development/tf_cloud/main.tf
@@ -14,6 +14,7 @@ module "tf_cloud_workspaces" {
   base_cluster_layer_working_directory    = var.base_cluster_layer_working_directory
   cluster_addons_layer_module_directories = var.cluster_addons_layer_module_directories
   cluster_addons_layer_working_directory  = var.cluster_addons_layer_working_directory
+  enable_cluster_addons_run_trigger       = var.enable_cluster_addons_run_trigger
   environment_name                        = var.environment_name
   google_cloud_working_directory          = var.google_cloud_working_directory
   source                                  = "../../../modules/tf_cloud/tf_cloud_workspaces"

--- a/terraform/env/development/tf_cloud/variables.tf
+++ b/terraform/env/development/tf_cloud/variables.tf
@@ -42,3 +42,9 @@ variable "TF_VAR_GITHUB_TOKEN" {
   type        = string
   sensitive   = true
 }
+
+variable "enable_cluster_addons_run_trigger" {
+  description = "When true, creates a run trigger so that a successful apply in the base cluster workspace automatically queues a run in the cluster addons workspace."
+  type        = bool
+  default     = true
+}

--- a/terraform/env/production/tf_cloud/main.tf
+++ b/terraform/env/production/tf_cloud/main.tf
@@ -13,6 +13,7 @@ resource "tfe_oauth_client" "github" {
 module "tf_cloud_workspaces" {
   base_cluster_layer_working_directory   = var.base_cluster_layer_working_directory
   cluster_addons_layer_working_directory = var.cluster_addons_layer_working_directory
+  enable_cluster_addons_run_trigger      = var.enable_cluster_addons_run_trigger
   environment_name                       = var.environment_name
   source                                 = "../../../modules/tf_cloud/tf_cloud_workspaces"
   tf_cloud_organization_name             = var.tf_cloud_organization_name

--- a/terraform/env/production/tf_cloud/variables.tf
+++ b/terraform/env/production/tf_cloud/variables.tf
@@ -30,3 +30,9 @@ variable "TF_VAR_GITHUB_TOKEN" {
   type        = string
   sensitive   = true
 }
+
+variable "enable_cluster_addons_run_trigger" {
+  description = "When true, creates a run trigger so that a successful apply in the base cluster workspace automatically queues a run in the cluster addons workspace."
+  type        = bool
+  default     = true
+}

--- a/terraform/env/staging/tf_cloud/main.tf
+++ b/terraform/env/staging/tf_cloud/main.tf
@@ -13,6 +13,7 @@ resource "tfe_oauth_client" "github" {
 module "tf_cloud_workspaces" {
   base_cluster_layer_working_directory   = var.base_cluster_layer_working_directory
   cluster_addons_layer_working_directory = var.cluster_addons_layer_working_directory
+  enable_cluster_addons_run_trigger      = var.enable_cluster_addons_run_trigger
   environment_name                       = var.environment_name
   source                                 = "../../../modules/tf_cloud/tf_cloud_workspaces"
   tf_cloud_organization_name             = var.tf_cloud_organization_name

--- a/terraform/env/staging/tf_cloud/variables.tf
+++ b/terraform/env/staging/tf_cloud/variables.tf
@@ -30,3 +30,9 @@ variable "TF_VAR_GITHUB_TOKEN" {
   type        = string
   sensitive   = true
 }
+
+variable "enable_cluster_addons_run_trigger" {
+  description = "When true, creates a run trigger so that a successful apply in the base cluster workspace automatically queues a run in the cluster addons workspace."
+  type        = bool
+  default     = true
+}

--- a/terraform/modules/tf_cloud/tf_cloud_workspaces/main.tf
+++ b/terraform/modules/tf_cloud/tf_cloud_workspaces/main.tf
@@ -16,6 +16,12 @@ resource "tfe_workspace_settings" "base_cluster_tfe_workspace" {
   remote_state_consumer_ids = [tfe_workspace.cluster_addons_tfe_workspace.id]
 }
 
+resource "tfe_run_trigger" "cluster_addons_run_trigger" {
+  count         = var.enable_cluster_addons_run_trigger ? 1 : 0
+  workspace_id  = tfe_workspace.cluster_addons_tfe_workspace.id
+  sourceable_id = tfe_workspace.base_cluster_tfe_workspace.id
+}
+
 resource "tfe_workspace" "cluster_addons_tfe_workspace" {
   name              = "ac_app_${var.environment_name}_cluster_addons_layer"
   organization      = var.tf_cloud_organization_name

--- a/terraform/modules/tf_cloud/tf_cloud_workspaces/variables.tf
+++ b/terraform/modules/tf_cloud/tf_cloud_workspaces/variables.tf
@@ -60,3 +60,9 @@ variable "tfe_workspace_tf_version" {
   type        = string
   default     = "1.3.7"
 }
+
+variable "enable_cluster_addons_run_trigger" {
+  description = "When true, creates a run trigger so that a successful apply in the base cluster workspace automatically queues a run in the cluster addons workspace."
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
Adds a tfe_run_trigger resource to the tf_cloud_workspaces module so that a successful apply in the base cluster workspace automatically queues a run in the cluster addons workspace. Controlled by the enable_cluster_addons_run_trigger variable (default: true) exposed at both the module and all environment tf_cloud config levels.