### PR TITLE
Disable custom launch template in base-cluster-layer for AL2023 compa…

### DIFF
--- a/terraform/modules/aws/base-cluster-layer/main.tf
+++ b/terraform/modules/aws/base-cluster-layer/main.tf
@@ -4,10 +4,11 @@ module "app_eks_cluster" {
   cluster_endpoint_public_access = true
 
   eks_managed_node_group_defaults = {
-    disk_size      = 20
-    instance_types = var.node_group_instance_types
-    ami_type       = var.ami_type
-    ami_id         = var.ami_id
+    disk_size                  = 20
+    instance_types             = var.node_group_instance_types
+    ami_type                   = var.ami_type
+    ami_id                     = var.ami_id
+    use_custom_launch_template = false
   }
 
   eks_managed_node_groups = {


### PR DESCRIPTION
…tibility

terraform-aws-modules/eks v19.5.x creates a custom launch template with AL2 bootstrap assumptions. This conflicts with AL2023's nodeadm bootstrap mechanism, causing nodes to boot but fail to register as healthy. Setting use_custom_launch_template = false lets EKS manage bootstrapping natively for AL2023.