### PR TITLE
Remove launch template output and data source after disabling custom …

### DIFF
--- a/terraform/env/development/aws/us-west-1/base-cluster-layer/outputs.tf
+++ b/terraform/env/development/aws/us-west-1/base-cluster-layer/outputs.tf
@@ -8,11 +8,6 @@ output "eks_cluster_oidc_provider_arn" {
   value       = module.eks_cluster.eks_cluster_oidc_provider_arn
 }
 
-output "eks_cluster_launch_template_name" {
-  description = "The name of the EKS cluster launch template"
-  value       = module.eks_cluster.eks_cluster_launch_template_name
-}
-
 output "environment_name" {
   description = "The name of the environment"
   value       = var.environment_name

--- a/terraform/env/development/aws/us-west-1/cluster-addons-layer/main.tf
+++ b/terraform/env/development/aws/us-west-1/cluster-addons-layer/main.tf
@@ -35,10 +35,6 @@ data "aws_eks_cluster_auth" "target_cluster_auth" {
   name = data.tfe_outputs.base_layer_state.nonsensitive_values.eks_cluster_name
 }
 
-data "aws_launch_template" "target_cluster_launch_template" {
-  name = data.tfe_outputs.base_layer_state.nonsensitive_values.eks_cluster_launch_template_name
-}
-
 data "tfe_outputs" "base_layer_state" {
   organization = var.tf_cloud_organization_name
   workspace    = var.tfe_base_layer_workspace_name
@@ -58,7 +54,7 @@ module "cluster_addons" {
 module "main_rails_app" {
   automation_calculator_helm_release_local_path = "../../../../../../helm/automation-calculator"
   automation_calculator_app_host                = var.automation_calculator_app_host
-  db_security_group_ids                         = data.aws_launch_template.target_cluster_launch_template.vpc_security_group_ids
+  db_security_group_ids                         = [data.aws_eks_cluster.target_cluster.vpc_config[0].cluster_security_group_id]
   db_subnet_group_ids                           = data.tfe_outputs.base_layer_state.nonsensitive_values.private_eks_subnet_ids
   db_port                                       = 5432
   depends_on = [

--- a/terraform/env/production/aws/us-west-1/base-cluster-layer/outputs.tf
+++ b/terraform/env/production/aws/us-west-1/base-cluster-layer/outputs.tf
@@ -8,11 +8,6 @@ output "eks_cluster_oidc_provider_arn" {
   value       = module.eks_cluster.eks_cluster_oidc_provider_arn
 }
 
-output "eks_cluster_launch_template_name" {
-  description = "The name of the EKS cluster launch template"
-  value       = module.eks_cluster.eks_cluster_launch_template_name
-}
-
 output "environment_name" {
   description = "The name of the environment"
   value       = var.environment_name

--- a/terraform/env/production/aws/us-west-1/cluster-addons-layer/main.tf
+++ b/terraform/env/production/aws/us-west-1/cluster-addons-layer/main.tf
@@ -35,10 +35,6 @@ data "aws_eks_cluster_auth" "target_cluster_auth" {
   name = data.tfe_outputs.base_layer_state.nonsensitive_values.eks_cluster_name
 }
 
-data "aws_launch_template" "target_cluster_launch_template" {
-  name = data.tfe_outputs.base_layer_state.nonsensitive_values.eks_cluster_launch_template_name
-}
-
 data "tfe_outputs" "base_layer_state" {
   organization = var.tf_cloud_organization_name
   workspace    = var.tfe_base_layer_workspace_name
@@ -58,7 +54,7 @@ module "cluster_addons" {
 module "main_rails_app" {
   automation_calculator_helm_release_local_path = "../../../../../../helm/automation-calculator"
   automation_calculator_app_host                = var.automation_calculator_app_host
-  db_security_group_ids                         = data.aws_launch_template.target_cluster_launch_template.vpc_security_group_ids
+  db_security_group_ids                         = [data.aws_eks_cluster.target_cluster.vpc_config[0].cluster_security_group_id]
   db_subnet_group_ids                           = data.tfe_outputs.base_layer_state.nonsensitive_values.private_eks_subnet_ids
   db_port                                       = 5432
   depends_on = [

--- a/terraform/env/staging/aws/us-west-1/base-cluster-layer/outputs.tf
+++ b/terraform/env/staging/aws/us-west-1/base-cluster-layer/outputs.tf
@@ -8,11 +8,6 @@ output "eks_cluster_oidc_provider_arn" {
   value       = module.eks_cluster.eks_cluster_oidc_provider_arn
 }
 
-output "eks_cluster_launch_template_name" {
-  description = "The name of the EKS cluster launch template"
-  value       = module.eks_cluster.eks_cluster_launch_template_name
-}
-
 output "environment_name" {
   description = "The name of the environment"
   value       = var.environment_name

--- a/terraform/env/staging/aws/us-west-1/cluster-addons-layer/main.tf
+++ b/terraform/env/staging/aws/us-west-1/cluster-addons-layer/main.tf
@@ -35,10 +35,6 @@ data "aws_eks_cluster_auth" "target_cluster_auth" {
   name = data.tfe_outputs.base_layer_state.nonsensitive_values.eks_cluster_name
 }
 
-data "aws_launch_template" "target_cluster_launch_template" {
-  name = data.tfe_outputs.base_layer_state.nonsensitive_values.eks_cluster_launch_template_name
-}
-
 data "tfe_outputs" "base_layer_state" {
   organization = var.tf_cloud_organization_name
   workspace    = var.tfe_base_layer_workspace_name
@@ -58,7 +54,7 @@ module "cluster_addons" {
 module "main_rails_app" {
   automation_calculator_helm_release_local_path = "../../../../../../helm/automation-calculator"
   automation_calculator_app_host                = var.automation_calculator_app_host
-  db_security_group_ids                         = data.aws_launch_template.target_cluster_launch_template.vpc_security_group_ids
+  db_security_group_ids                         = [data.aws_eks_cluster.target_cluster.vpc_config[0].cluster_security_group_id]
   db_subnet_group_ids                           = data.tfe_outputs.base_layer_state.nonsensitive_values.private_eks_subnet_ids
   db_port                                       = 5432
   depends_on = [

--- a/terraform/modules/aws/base-cluster-layer/outputs.tf
+++ b/terraform/modules/aws/base-cluster-layer/outputs.tf
@@ -14,6 +14,3 @@ output "eks_cluster_oidc_provider_arn" {
   value = module.app_eks_cluster.oidc_provider_arn
 }
 
-output "eks_cluster_launch_template_name" {
-  value = module.app_eks_cluster.eks_managed_node_groups.primary.launch_template_name
-}


### PR DESCRIPTION
…launch template

With use_custom_launch_template=false set for AL2023 compatibility, no launch template is created so the output is null and absent from TFE nonsensitive_values. Replace vpc_security_group_ids from the launch template with the EKS cluster's cluster_security_group_id for DB access rules across all envs.