### PR TITLE
Override ALB controller image to ECR Public to fix image pull backoff

### DIFF
--- a/terraform/modules/aws/cluster-addons-layer/main.tf
+++ b/terraform/modules/aws/cluster-addons-layer/main.tf
@@ -58,6 +58,11 @@ resource "helm_release" "aws_load_balancer_controller" {
     value = var.vpc_id
   }
 
+  set {
+    name  = "image.repository"
+    value = "public.ecr.aws/eks/aws-load-balancer-controller"
+  }
+
   version = "1.4.6"
 }
 


### PR DESCRIPTION
Chart 1.4.6 defaults to pulling v2.4.5 from the private regional ECR (602401143452.dkr.ecr.us-west-1.amazonaws.com), which fails when node IAM permissions are missing. ECR Public is accessible from within AWS without auth, matching the pattern used for external-dns.