### PR TITLE
Fix period must not be null on unhealthy hosts alarm

### DIFF
--- a/terraform/modules/aws/cluster-addons-layer/cloudwatch_alarms.tf
+++ b/terraform/modules/aws/cluster-addons-layer/cloudwatch_alarms.tf
@@ -99,6 +99,7 @@ resource "aws_cloudwatch_metric_alarm" "unhealthy_hosts" {
     id          = "max_unhealthy"
     expression  = "MAX(tg_unhealthy)"
     label       = "Max Unhealthy Hosts"
+    period      = 60
     return_data = true
   }
 


### PR DESCRIPTION
CloudWatch requires an explicit period on the return_data metric_query when all queries are math expressions (no direct metric block).