### PR TITLE
Fix ami_type: rename AL2023_x86_64 to AL2023_x86_64_STANDARD for EKS module v21 compatibility

### DIFF
--- a/terraform/env/development/aws/us-west-1/base-cluster-layer/terraform.tfvars
+++ b/terraform/env/development/aws/us-west-1/base-cluster-layer/terraform.tfvars
@@ -1,4 +1,4 @@
 environment_name           = "development"
 project_tag                = "automation-calculator"
 kubernetes_cluster_version = "1.29"
-ami_type                   = "AL2023_x86_64"
+ami_type                   = "AL2023_x86_64_STANDARD"

--- a/terraform/env/production/aws/us-west-1/base-cluster-layer/terraform.tfvars
+++ b/terraform/env/production/aws/us-west-1/base-cluster-layer/terraform.tfvars
@@ -1,4 +1,4 @@
 environment_name           = "production"
 project_tag                = "automation-calculator"
 kubernetes_cluster_version = "1.35"
-ami_type                   = "AL2023_x86_64"
+ami_type                   = "AL2023_x86_64_STANDARD"

--- a/terraform/env/staging/aws/us-west-1/base-cluster-layer/terraform.tfvars
+++ b/terraform/env/staging/aws/us-west-1/base-cluster-layer/terraform.tfvars
@@ -1,4 +1,4 @@
 environment_name           = "staging"
 project_tag                = "automation-calculator"
 kubernetes_cluster_version = "1.35"
-ami_type                   = "AL2023_x86_64"
+ami_type                   = "AL2023_x86_64_STANDARD"


### PR DESCRIPTION
EKS module v21 renamed `AL2023_x86_64` to `AL2023_x86_64_STANDARD`. The old value is no longer present in the module's `ami_type_to_user_data_path` and `ssm_ami_type_to_ssm_param` lookup maps, causing "Invalid index" errors during plan in staging and production.

Updates `ami_type` in all three env tfvars to use the new name.