### PR TITLE
Gate CloudWatch alarms behind cloudwatch_alarms_enabled variable

### DIFF
--- a/terraform/env/production/aws/us-west-1/cluster-addons-layer/main.tf
+++ b/terraform/env/production/aws/us-west-1/cluster-addons-layer/main.tf
@@ -13,6 +13,7 @@ data "tfe_outputs" "base_layer_state" {
 
 module "cluster_addons" {
   alarm_email                   = var.alarm_email
+  cloudwatch_alarms_enabled     = true
   environment_name              = data.tfe_outputs.base_layer_state.nonsensitive_values.environment_name
   eks_cluster_name              = data.tfe_outputs.base_layer_state.nonsensitive_values.eks_cluster_name
   eks_cluster_api_endpoint      = data.aws_eks_cluster.target_cluster.endpoint

--- a/terraform/modules/aws/cluster-addons-layer/cloudwatch_alarms.tf
+++ b/terraform/modules/aws/cluster-addons-layer/cloudwatch_alarms.tf
@@ -1,25 +1,26 @@
 data "aws_lb" "app" {
-  name = "ac-app-${var.environment_name}"
+  count = var.cloudwatch_alarms_enabled ? 1 : 0
+  name  = "ac-app-${var.environment_name}"
 }
 
 locals {
-  # CloudWatch expects the ALB dimension as the ARN suffix, e.g.:
-  # arn:aws:elasticloadbalancing:...:loadbalancer/app/ac-app-production/abc123
-  # → "app/ac-app-production/abc123"
-  alb_dimension = join("/", slice(split("/", data.aws_lb.app.arn), 1, 4))
+  alb_dimension = try(join("/", slice(split("/", data.aws_lb.app[0].arn), 1, 4)), "")
 }
 
 resource "aws_sns_topic" "alarms" {
-  name = "ac-app-${var.environment_name}-alarms"
+  count = var.cloudwatch_alarms_enabled ? 1 : 0
+  name  = "ac-app-${var.environment_name}-alarms"
 }
 
 resource "aws_sns_topic_subscription" "alarms_email" {
-  topic_arn = aws_sns_topic.alarms.arn
+  count     = var.cloudwatch_alarms_enabled ? 1 : 0
+  topic_arn = aws_sns_topic.alarms[0].arn
   protocol  = "email"
   endpoint  = var.alarm_email
 }
 
 resource "aws_cloudwatch_metric_alarm" "alb_5xx_errors" {
+  count               = var.cloudwatch_alarms_enabled ? 1 : 0
   alarm_name          = "ac-app-${var.environment_name}-alb-5xx-errors"
   alarm_description   = "ALB is returning 5xx errors"
   comparison_operator = "GreaterThanThreshold"
@@ -35,11 +36,12 @@ resource "aws_cloudwatch_metric_alarm" "alb_5xx_errors" {
     LoadBalancer = local.alb_dimension
   }
 
-  alarm_actions = [aws_sns_topic.alarms.arn]
-  ok_actions    = [aws_sns_topic.alarms.arn]
+  alarm_actions = [aws_sns_topic.alarms[0].arn]
+  ok_actions    = [aws_sns_topic.alarms[0].arn]
 }
 
 resource "aws_cloudwatch_metric_alarm" "target_5xx_errors" {
+  count               = var.cloudwatch_alarms_enabled ? 1 : 0
   alarm_name          = "ac-app-${var.environment_name}-target-5xx-errors"
   alarm_description   = "App instances are returning 5xx errors"
   comparison_operator = "GreaterThanThreshold"
@@ -55,11 +57,12 @@ resource "aws_cloudwatch_metric_alarm" "target_5xx_errors" {
     LoadBalancer = local.alb_dimension
   }
 
-  alarm_actions = [aws_sns_topic.alarms.arn]
-  ok_actions    = [aws_sns_topic.alarms.arn]
+  alarm_actions = [aws_sns_topic.alarms[0].arn]
+  ok_actions    = [aws_sns_topic.alarms[0].arn]
 }
 
 resource "aws_cloudwatch_metric_alarm" "alb_latency_p99" {
+  count               = var.cloudwatch_alarms_enabled ? 1 : 0
   alarm_name          = "ac-app-${var.environment_name}-latency-p99"
   alarm_description   = "ALB p99 response time exceeded 3 seconds"
   comparison_operator = "GreaterThanThreshold"
@@ -75,11 +78,12 @@ resource "aws_cloudwatch_metric_alarm" "alb_latency_p99" {
     LoadBalancer = local.alb_dimension
   }
 
-  alarm_actions = [aws_sns_topic.alarms.arn]
-  ok_actions    = [aws_sns_topic.alarms.arn]
+  alarm_actions = [aws_sns_topic.alarms[0].arn]
+  ok_actions    = [aws_sns_topic.alarms[0].arn]
 }
 
 resource "aws_cloudwatch_metric_alarm" "unhealthy_hosts" {
+  count               = var.cloudwatch_alarms_enabled ? 1 : 0
   alarm_name          = "ac-app-${var.environment_name}-unhealthy-hosts"
   alarm_description   = "One or more target group hosts are unhealthy"
   comparison_operator = "GreaterThanThreshold"
@@ -95,6 +99,6 @@ resource "aws_cloudwatch_metric_alarm" "unhealthy_hosts" {
     LoadBalancer = local.alb_dimension
   }
 
-  alarm_actions = [aws_sns_topic.alarms.arn]
-  ok_actions    = [aws_sns_topic.alarms.arn]
+  alarm_actions = [aws_sns_topic.alarms[0].arn]
+  ok_actions    = [aws_sns_topic.alarms[0].arn]
 }

--- a/terraform/modules/aws/cluster-addons-layer/variables.tf
+++ b/terraform/modules/aws/cluster-addons-layer/variables.tf
@@ -33,3 +33,9 @@ variable "alarm_email" {
   description = "Email address to receive CloudWatch alarm notifications"
   type        = string
 }
+
+variable "cloudwatch_alarms_enabled" {
+  description = "Set to true to create the CloudWatch alarms and SNS alerting resources. Requires the app ALB to exist, so must be false on initial bootstrap."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## Summary

- Adds `cloudwatch_alarms_enabled` variable (default `false`) to the `cluster-addons-layer` module
- Gates `data.aws_lb.app`, the SNS topic/subscription, and all four CloudWatch metric alarms behind `count = var.cloudwatch_alarms_enabled ? 1 : 0`
- Production env explicitly sets `cloudwatch_alarms_enabled = true`; dev and staging inherit `false`

**Fixes:** Fresh-environment bootstrap failure where `data "aws_lb" "app"` errored with _couldn't find resource_ because the ALB doesn't exist until after the app Ingress is processed by the ALB controller.

## Test plan

- [ ] `terraform plan` on a fresh staging env apply succeeds without the ALB lookup error
- [ ] `terraform plan` on production shows no alarm resource changes (alarms already exist, flag is now explicit `true`)
- [ ] CI fmt-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)