### PR TITLE
Add TFC workspace for production route53-domains env config

### DIFF
--- a/terraform/env/production/tf_cloud/main.tf
+++ b/terraform/env/production/tf_cloud/main.tf
@@ -11,7 +11,9 @@ module "tf_cloud_workspaces" {
   base_cluster_layer_working_directory   = var.base_cluster_layer_working_directory
   cluster_addons_layer_working_directory = var.cluster_addons_layer_working_directory
   enable_cluster_addons_run_trigger      = var.enable_cluster_addons_run_trigger
+  enable_route53_domains_workspace       = var.enable_route53_domains_workspace
   environment_name                       = var.environment_name
+  route53_domains_working_directory      = var.route53_domains_working_directory
   source                                 = "../../../modules/tf_cloud/tf_cloud_workspaces"
   tf_cloud_organization_name             = var.tf_cloud_organization_name
   tf_cloud_workspace_vcs_repo_identifier = var.tf_cloud_workspace_vcs_repo_identifier

--- a/terraform/env/production/tf_cloud/terraform.tfvars
+++ b/terraform/env/production/tf_cloud/terraform.tfvars
@@ -1,4 +1,6 @@
 base_cluster_layer_working_directory   = "terraform/env/production/aws/us-west-1/base-cluster-layer"
 cluster_addons_layer_working_directory = "terraform/env/production/aws/us-west-1/cluster-addons-layer"
+enable_route53_domains_workspace       = true
 environment_name                       = "production"
+route53_domains_working_directory      = "terraform/env/production/aws/us-east-1/route53-domains"
 tfe_workspace_tf_version               = "1.11"

--- a/terraform/env/production/tf_cloud/variables.tf
+++ b/terraform/env/production/tf_cloud/variables.tf
@@ -48,3 +48,15 @@ variable "tfe_workspace_tf_version" {
   type        = string
   default     = "1.3.7"
 }
+
+variable "enable_route53_domains_workspace" {
+  description = "When true, creates a TFC workspace for the route53-domains env config."
+  type        = bool
+  default     = false
+}
+
+variable "route53_domains_working_directory" {
+  description = "The path to the route53-domains env config directory."
+  type        = string
+  default     = ""
+}

--- a/terraform/modules/tf_cloud/tf_cloud_workspaces/main.tf
+++ b/terraform/modules/tf_cloud/tf_cloud_workspaces/main.tf
@@ -23,6 +23,21 @@ resource "tfe_run_trigger" "cluster_addons_run_trigger" {
   sourceable_id = tfe_workspace.base_cluster_tfe_workspace.id
 }
 
+resource "tfe_workspace" "route53_domains_tfe_workspace" {
+  count             = var.enable_route53_domains_workspace ? 1 : 0
+  name              = "ac_app_${var.environment_name}_route53_domains"
+  organization      = var.tf_cloud_organization_name
+  auto_apply        = var.auto_apply
+  tag_names         = local.shared_workspace_tags
+  terraform_version = var.tfe_workspace_tf_version
+  trigger_prefixes  = concat([var.route53_domains_working_directory], var.route53_domains_module_directories)
+  vcs_repo {
+    identifier     = var.tf_cloud_workspace_vcs_repo_identifier
+    oauth_token_id = var.tfe_oauth_client_token_id
+  }
+  working_directory = var.route53_domains_working_directory
+}
+
 resource "tfe_workspace" "cluster_addons_tfe_workspace" {
   name              = "ac_app_${var.environment_name}_cluster_addons_layer"
   organization      = var.tf_cloud_organization_name

--- a/terraform/modules/tf_cloud/tf_cloud_workspaces/variables.tf
+++ b/terraform/modules/tf_cloud/tf_cloud_workspaces/variables.tf
@@ -72,3 +72,21 @@ variable "auto_apply" {
   type        = bool
   default     = false
 }
+
+variable "enable_route53_domains_workspace" {
+  description = "When true, creates a TFC workspace for the route53-domains env config."
+  type        = bool
+  default     = false
+}
+
+variable "route53_domains_working_directory" {
+  description = "The path to the route53-domains env config directory."
+  type        = string
+  default     = ""
+}
+
+variable "route53_domains_module_directories" {
+  description = "Module directories that trigger a run in the route53-domains workspace."
+  type        = list(string)
+  default     = ["terraform/modules/aws/route53-domain"]
+}


### PR DESCRIPTION
- Adds opt-in route53_domains workspace to the tf_cloud_workspaces module (enable_route53_domains_workspace, default false so dev/staging are unaffected)
- Enables it for production, pointing at terraform/env/production/aws/us-east-1/route53-domains
- Workspace name: ac_app_production_route53_domains
- trigger_prefixes covers both the env config dir and terraform/modules/aws/route53-domain