### PR TITLE
Add Gmail MX record for automation-calculations.net

### DIFF
--- a/terraform/env/production/aws/us-east-1/route53-domains/dns.tf
+++ b/terraform/env/production/aws/us-east-1/route53-domains/dns.tf
@@ -1,0 +1,7 @@
+resource "aws_route53_record" "gmail_mx" {
+  zone_id = module.route53_domains["automation-calculations.net"].hosted_zone_id
+  name    = "automation-calculations.net"
+  type    = "MX"
+  ttl     = 60
+  records = ["1 SMTP.GOOGLE.COM."]
+}


### PR DESCRIPTION
Adds an MX record to the Route 53 hosted zone pointing to SMTP.GOOGLE.COM
with priority 1 and TTL 60, enabling Gmail on the domain.