### PR TITLE
Import automation-calculations.io Route 53 domain into IaC

### DIFF
--- a/terraform/env/production/aws/us-east-1/route53-domains/import.tf
+++ b/terraform/env/production/aws/us-east-1/route53-domains/import.tf
@@ -2,3 +2,8 @@ import {
   to = module.route53_domains["automation-calculations.net"].aws_route53domains_registered_domain.this
   id = "automation-calculations.net"
 }
+
+import {
+  to = module.route53_domains["automation-calculations.io"].aws_route53domains_registered_domain.this
+  id = "automation-calculations.io"
+}

--- a/terraform/env/production/aws/us-east-1/route53-domains/terraform.tfvars
+++ b/terraform/env/production/aws/us-east-1/route53-domains/terraform.tfvars
@@ -1,5 +1,6 @@
 environment_name = "production"
 
 domain_names = [
+  "automation-calculations.io",
   "automation-calculations.net",
 ]


### PR DESCRIPTION
Adds automation-calculations.io to the production route53-domains env config alongside automation-calculations.net. Uses the same import block pattern to bring the existing console-registered domain under Terraform management.