### PR TITLE
Add Route 53 health checks to route53-domain module

### DIFF
--- a/terraform/env/production/aws/us-east-1/route53-domains/main.tf
+++ b/terraform/env/production/aws/us-east-1/route53-domains/main.tf
@@ -1,6 +1,10 @@
 module "route53_domains" {
-  for_each           = var.domain_names
-  source             = "../../../../../modules/aws/route53-domain"
-  domain_name        = each.key
-  privacy_protection = true
+  for_each            = var.domain_names
+  source              = "../../../../../modules/aws/route53-domain"
+  domain_name         = each.key
+  privacy_protection  = true
+  enable_health_check = each.value.enable_health_check
+  health_check_path   = each.value.health_check_path
+  health_check_port   = each.value.health_check_port
+  health_check_type   = each.value.health_check_type
 }

--- a/terraform/env/production/aws/us-east-1/route53-domains/outputs.tf
+++ b/terraform/env/production/aws/us-east-1/route53-domains/outputs.tf
@@ -1,10 +1,11 @@
 output "domains" {
-  description = "Per-domain hosted zone ID, name servers, and expiration date."
+  description = "Per-domain hosted zone ID, name servers, expiration date, and health check ID."
   value = {
     for name, mod in module.route53_domains : name => {
       hosted_zone_id  = mod.hosted_zone_id
       name_servers    = mod.name_servers
       expiration_date = mod.expiration_date
+      health_check_id = mod.health_check_id
     }
   }
 }

--- a/terraform/env/production/aws/us-east-1/route53-domains/terraform.tfvars
+++ b/terraform/env/production/aws/us-east-1/route53-domains/terraform.tfvars
@@ -1,6 +1,8 @@
 environment_name = "production"
 
-domain_names = [
-  "automation-calculations.io",
-  "automation-calculations.net",
-]
+domain_names = {
+  "automation-calculations.io" = {
+    enable_health_check = true
+  }
+  "automation-calculations.net" = {}
+}

--- a/terraform/env/production/aws/us-east-1/route53-domains/variables.tf
+++ b/terraform/env/production/aws/us-east-1/route53-domains/variables.tf
@@ -16,7 +16,14 @@ variable "project_tag" {
 }
 
 variable "domain_names" {
-  description = "Set of domain names to register via Route 53."
-  type        = set(string)
-  default     = ["automation-calculations.net"]
+  description = "Map of domain names to per-domain configuration."
+  type = map(object({
+    enable_health_check = optional(bool, false)
+    health_check_path   = optional(string, "/")
+    health_check_port   = optional(number, 443)
+    health_check_type   = optional(string, "HTTPS")
+  }))
+  default = {
+    "automation-calculations.net" = {}
+  }
 }

--- a/terraform/modules/aws/route53-domain/main.tf
+++ b/terraform/modules/aws/route53-domain/main.tf
@@ -16,3 +16,18 @@ data "aws_route53_zone" "this" {
   name         = aws_route53domains_registered_domain.this.domain_name
   private_zone = false
 }
+
+resource "aws_route53_health_check" "this" {
+  count = var.enable_health_check ? 1 : 0
+
+  fqdn              = var.domain_name
+  port              = var.health_check_port
+  type              = var.health_check_type
+  resource_path     = var.health_check_path
+  failure_threshold = 3
+  request_interval  = 30
+
+  tags = {
+    Project = "automation_calculator"
+  }
+}

--- a/terraform/modules/aws/route53-domain/outputs.tf
+++ b/terraform/modules/aws/route53-domain/outputs.tf
@@ -27,3 +27,8 @@ output "name_servers" {
   description = "Name servers in the delegation set for the hosted zone."
   value       = data.aws_route53_zone.this.name_servers
 }
+
+output "health_check_id" {
+  description = "The ID of the Route 53 health check, or null if not enabled."
+  value       = length(aws_route53_health_check.this) > 0 ? aws_route53_health_check.this[0].id : null
+}

--- a/terraform/modules/aws/route53-domain/variables.tf
+++ b/terraform/modules/aws/route53-domain/variables.tf
@@ -21,3 +21,27 @@ variable "privacy_protection" {
   type        = bool
   default     = true
 }
+
+variable "enable_health_check" {
+  description = "Whether to create a Route 53 health check for this domain."
+  type        = bool
+  default     = false
+}
+
+variable "health_check_path" {
+  description = "Path to request for the health check."
+  type        = string
+  default     = "/"
+}
+
+variable "health_check_port" {
+  description = "Port to use for the health check."
+  type        = number
+  default     = 443
+}
+
+variable "health_check_type" {
+  description = "Protocol for the health check (HTTP, HTTPS, HTTP_STR_MATCH, HTTPS_STR_MATCH, TCP)."
+  type        = string
+  default     = "HTTPS"
+}


### PR DESCRIPTION
- Adds optional health check support to the  module via , , , and  variables (all defaulting to off / HTTPS on port 443 at /)
- Changes `domain_names` in the production env config from a `set(string)` to a `map(object)` so each domain can carry its own configuration
- Enables the health check for `automation-calculations.io`; `automation-calculations.net` remains unchanged with health checks off