### PR TITLE
Bump dev and staging RDS PostgreSQL to 15.17

### DIFF
--- a/terraform/env/development/aws/us-west-1/cluster-addons-layer/terraform.tfvars
+++ b/terraform/env/development/aws/us-west-1/cluster-addons-layer/terraform.tfvars
@@ -1,4 +1,4 @@
 alarm_email                    = "steven.uray@automation-caluclations.net"
 automation_calculator_app_host = "development.automation-calculations.io"
-db_engine_version              = "14.22"
+db_engine_version              = "15.17"
 tfe_base_layer_workspace_name  = "ac_app_development_base_cluster_layer"

--- a/terraform/env/staging/aws/us-west-1/cluster-addons-layer/terraform.tfvars
+++ b/terraform/env/staging/aws/us-west-1/cluster-addons-layer/terraform.tfvars
@@ -1,4 +1,4 @@
 alarm_email                    = "steven.uray@automation-caluclations.net"
 automation_calculator_app_host = "staging.automation-calculations.io"
-db_engine_version              = "14.22"
+db_engine_version              = "15.17"
 tfe_base_layer_workspace_name  = "ac_app_staging_base_cluster_layer"


### PR DESCRIPTION
Upgrades dev and staging cluster-addons-layer from PostgreSQL 14.22 to 15.17 (latest 15.x minor version as of Feb 2026). Production remains on 14.x.