### PR TITLE
Bump prod RDS PostgreSQL to 15.17

### DIFF
--- a/terraform/env/production/aws/us-west-1/cluster-addons-layer/terraform.tfvars
+++ b/terraform/env/production/aws/us-west-1/cluster-addons-layer/terraform.tfvars
@@ -1,4 +1,4 @@
 alarm_email                    = "steven.uray@automation-caluclations.net"
 automation_calculator_app_host = "automation-calculations.io"
-db_engine_version              = "14.22"
+db_engine_version              = "15.17"
 tfe_base_layer_workspace_name  = "ac_app_production_base_cluster_layer"


### PR DESCRIPTION
Upgrades production cluster-addons-layer from PostgreSQL 14.22 to 15.17 (latest 15.x minor version).