### PR TITLE
Bump dev and staging RDS PostgreSQL to 16.13

### DIFF
--- a/terraform/env/development/aws/us-west-1/cluster-addons-layer/terraform.tfvars
+++ b/terraform/env/development/aws/us-west-1/cluster-addons-layer/terraform.tfvars
@@ -1,4 +1,4 @@
 alarm_email                    = "steven.uray@automation-caluclations.net"
 automation_calculator_app_host = "development.automation-calculations.io"
-db_engine_version              = "15.17"
+db_engine_version              = "16.13"
 tfe_base_layer_workspace_name  = "ac_app_development_base_cluster_layer"

--- a/terraform/env/staging/aws/us-west-1/cluster-addons-layer/terraform.tfvars
+++ b/terraform/env/staging/aws/us-west-1/cluster-addons-layer/terraform.tfvars
@@ -1,4 +1,4 @@
 alarm_email                    = "steven.uray@automation-caluclations.net"
 automation_calculator_app_host = "staging.automation-calculations.io"
-db_engine_version              = "15.17"
+db_engine_version              = "16.13"
 tfe_base_layer_workspace_name  = "ac_app_staging_base_cluster_layer"


### PR DESCRIPTION
Upgrades dev and staging cluster-addons-layer from PostgreSQL 15.17 to 16.13 (latest 16.x minor version). Production remains on 15.17.