### PR TITLE
Refactor app version to be set per-env via tfvars

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,10 +175,15 @@ jobs:
       - run:
           name: Validate app Docker image versions exist on Docker Hub
           command: |
+            git fetch origin main
+            CHANGED_VERSIONS=$(git diff origin/main...HEAD -- terraform/env/*/aws/us-west-1/cluster-addons-layer/terraform.tfvars | grep '^+app_version' | grep -oP '"\K[^"]+' | sort -u)
+            if [ -z "${CHANGED_VERSIONS}" ]; then
+              echo "No app_version changes detected, skipping Docker Hub validation"
+              exit 0
+            fi
             IMAGE_REPO="automationcalculationsci/automation-calculator"
-            VERSIONS=$(grep 'app_version' terraform/env/*/aws/us-west-1/cluster-addons-layer/terraform.tfvars | grep -oP '"\K[^"]+' | sort -u)
             FAILED=0
-            for VERSION in $VERSIONS; do
+            for VERSION in $CHANGED_VERSIONS; do
               HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://hub.docker.com/v2/repositories/${IMAGE_REPO}/tags/${VERSION}/")
               if [ "${HTTP_STATUS}" = "200" ]; then
                 echo "OK: ${IMAGE_REPO}:${VERSION}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,6 +167,28 @@ jobs:
       - terraform/validate:
           path: ./terraform/env/production/aws/us-east-1/route53-domains
 
+  validate_app_docker_image_versions:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - checkout
+      - run:
+          name: Validate app Docker image versions exist on Docker Hub
+          command: |
+            IMAGE_REPO="automationcalculationsci/automation-calculator"
+            VERSIONS=$(grep 'app_version' terraform/env/*/aws/us-west-1/cluster-addons-layer/terraform.tfvars | grep -oP '"\K[^"]+' | sort -u)
+            FAILED=0
+            for VERSION in $VERSIONS; do
+              HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://hub.docker.com/v2/repositories/${IMAGE_REPO}/tags/${VERSION}/")
+              if [ "${HTTP_STATUS}" = "200" ]; then
+                echo "OK: ${IMAGE_REPO}:${VERSION}"
+              else
+                echo "MISSING: ${IMAGE_REPO}:${VERSION} (HTTP ${HTTP_STATUS})"
+                FAILED=1
+              fi
+            done
+            exit ${FAILED}
+
 workflows:
   validate:
     jobs:
@@ -187,3 +209,4 @@ workflows:
       - validate_networking_module
       - validate_route53_domain_module
       - validate_production_aws_route53_domains
+      - validate_app_docker_image_versions

--- a/scripts/bump_app_docker_image_version.sh
+++ b/scripts/bump_app_docker_image_version.sh
@@ -9,7 +9,9 @@ set -euo pipefail
 # This script assumes that the docker image has already been pushed to the registry
 
 HELM_VALUES_FILE="../helm/automation-calculator/values.yaml"
-TERRAFORM_APP_MODULE_VARIABLES_FILE="../terraform/modules/aws/main_rails_app/variables.tf"
+DEV_TFVARS="../terraform/env/development/aws/us-west-1/cluster-addons-layer/terraform.tfvars"
+STAGING_TFVARS="../terraform/env/staging/aws/us-west-1/cluster-addons-layer/terraform.tfvars"
+PROD_TFVARS="../terraform/env/production/aws/us-west-1/cluster-addons-layer/terraform.tfvars"
 NEW_VERSION=${1}
 
 if [ $# -ne 1 ]; then
@@ -18,7 +20,9 @@ if [ $# -ne 1 ]; then
 fi
 
 ls ${HELM_VALUES_FILE}
-ls ${TERRAFORM_APP_MODULE_VARIABLES_FILE}
+ls ${DEV_TFVARS}
+ls ${STAGING_TFVARS}
+ls ${PROD_TFVARS}
 
 YQ_EXPRESSION=".image.tag=\"${NEW_VERSION}\""
 
@@ -26,4 +30,6 @@ OLD_TAG_VALUE=$(yq -r .image.tag ${HELM_VALUES_FILE})
 
 yq -i ${HELM_VALUES_FILE} --expression ${YQ_EXPRESSION}
 
-sed -i -e "s/${OLD_TAG_VALUE}/${NEW_VERSION}/g" ${TERRAFORM_APP_MODULE_VARIABLES_FILE}
+for TFVARS_FILE in "${DEV_TFVARS}" "${STAGING_TFVARS}" "${PROD_TFVARS}"; do
+    sed -i '' "s/${OLD_TAG_VALUE}/${NEW_VERSION}/g" "${TFVARS_FILE}"
+done

--- a/scripts/bump_app_docker_image_version_branch.sh
+++ b/scripts/bump_app_docker_image_version_branch.sh
@@ -25,7 +25,9 @@ git checkout -b bump-app-docker-image-version-${NEW_VERSION}
 
 #commit changes
 git add ../helm/automation-calculator/values.yaml
-git add ../terraform/modules/aws/main_rails_app/variables.tf
+git add ../terraform/env/development/aws/us-west-1/cluster-addons-layer/terraform.tfvars
+git add ../terraform/env/staging/aws/us-west-1/cluster-addons-layer/terraform.tfvars
+git add ../terraform/env/production/aws/us-west-1/cluster-addons-layer/terraform.tfvars
 
 git commit -m "Bump app docker image version to ${NEW_VERSION}"
 

--- a/terraform/env/development/aws/us-west-1/cluster-addons-layer/main.tf
+++ b/terraform/env/development/aws/us-west-1/cluster-addons-layer/main.tf
@@ -24,6 +24,7 @@ module "cluster_addons" {
 
 module "main_rails_app" {
   automation_calculator_helm_release_local_path = "../../../../../../helm/automation-calculator"
+  app_version                                   = var.app_version
   automation_calculator_app_host                = var.automation_calculator_app_host
   db_engine_version                             = var.db_engine_version
   db_security_group_ids                         = [data.aws_eks_cluster.target_cluster.vpc_config[0].cluster_security_group_id]

--- a/terraform/env/development/aws/us-west-1/cluster-addons-layer/terraform.tfvars
+++ b/terraform/env/development/aws/us-west-1/cluster-addons-layer/terraform.tfvars
@@ -1,4 +1,5 @@
 alarm_email                    = "steven.uray@automation-caluclations.net"
+app_version                    = "0.9.6-698"
 automation_calculator_app_host = "development.automation-calculations.io"
 db_engine_version              = "16.13"
 tfe_base_layer_workspace_name  = "ac_app_development_base_cluster_layer"

--- a/terraform/env/development/aws/us-west-1/cluster-addons-layer/variables.tf
+++ b/terraform/env/development/aws/us-west-1/cluster-addons-layer/variables.tf
@@ -58,6 +58,11 @@ variable "alarm_email" {
   type        = string
 }
 
+variable "app_version" {
+  description = "The version of the automation-calculator app to deploy."
+  type        = string
+}
+
 variable "db_engine_version" {
   description = "The PostgreSQL engine version for the RDS instance."
   type        = string

--- a/terraform/env/production/aws/us-west-1/cluster-addons-layer/main.tf
+++ b/terraform/env/production/aws/us-west-1/cluster-addons-layer/main.tf
@@ -25,6 +25,7 @@ module "cluster_addons" {
 
 module "main_rails_app" {
   automation_calculator_helm_release_local_path = "../../../../../../helm/automation-calculator"
+  app_version                                   = var.app_version
   automation_calculator_app_host                = var.automation_calculator_app_host
   db_engine_version                             = var.db_engine_version
   db_security_group_ids                         = [data.aws_eks_cluster.target_cluster.vpc_config[0].cluster_security_group_id]

--- a/terraform/env/production/aws/us-west-1/cluster-addons-layer/terraform.tfvars
+++ b/terraform/env/production/aws/us-west-1/cluster-addons-layer/terraform.tfvars
@@ -1,4 +1,5 @@
 alarm_email                    = "steven.uray@automation-caluclations.net"
+app_version                    = "0.9.6-698"
 automation_calculator_app_host = "automation-calculations.io"
 db_engine_version              = "16.13"
 tfe_base_layer_workspace_name  = "ac_app_production_base_cluster_layer"

--- a/terraform/env/production/aws/us-west-1/cluster-addons-layer/variables.tf
+++ b/terraform/env/production/aws/us-west-1/cluster-addons-layer/variables.tf
@@ -57,6 +57,11 @@ variable "alarm_email" {
   type        = string
 }
 
+variable "app_version" {
+  description = "The version of the automation-calculator app to deploy."
+  type        = string
+}
+
 variable "db_engine_version" {
   description = "The PostgreSQL engine version for the RDS instance."
   type        = string

--- a/terraform/env/staging/aws/us-west-1/cluster-addons-layer/main.tf
+++ b/terraform/env/staging/aws/us-west-1/cluster-addons-layer/main.tf
@@ -24,6 +24,7 @@ module "cluster_addons" {
 
 module "main_rails_app" {
   automation_calculator_helm_release_local_path = "../../../../../../helm/automation-calculator"
+  app_version                                   = var.app_version
   automation_calculator_app_host                = var.automation_calculator_app_host
   db_engine_version                             = var.db_engine_version
   db_security_group_ids                         = [data.aws_eks_cluster.target_cluster.vpc_config[0].cluster_security_group_id]

--- a/terraform/env/staging/aws/us-west-1/cluster-addons-layer/terraform.tfvars
+++ b/terraform/env/staging/aws/us-west-1/cluster-addons-layer/terraform.tfvars
@@ -1,4 +1,5 @@
 alarm_email                    = "steven.uray@automation-caluclations.net"
+app_version                    = "0.9.6-698"
 automation_calculator_app_host = "staging.automation-calculations.io"
 db_engine_version              = "16.13"
 tfe_base_layer_workspace_name  = "ac_app_staging_base_cluster_layer"

--- a/terraform/env/staging/aws/us-west-1/cluster-addons-layer/variables.tf
+++ b/terraform/env/staging/aws/us-west-1/cluster-addons-layer/variables.tf
@@ -57,6 +57,11 @@ variable "alarm_email" {
   type        = string
 }
 
+variable "app_version" {
+  description = "The version of the automation-calculator app to deploy."
+  type        = string
+}
+
 variable "db_engine_version" {
   description = "The PostgreSQL engine version for the RDS instance."
   type        = string

--- a/terraform/modules/aws/main_rails_app/variables.tf
+++ b/terraform/modules/aws/main_rails_app/variables.tf
@@ -12,7 +12,6 @@ variable "app_image_repo" {
 }
 
 variable "app_version" {
-  default     = "0.9.6-698"
   description = "The version of the automation-calculator app to deploy."
   type        = string
 }


### PR DESCRIPTION
Previously, app_version was set as a default in the main_rails_app module, meaning all environments shared the same value and bumps required editing the module itself. This refactor moves app_version into each env's terraform.tfvars so environments can be bumped independently.

- Remove default from app_version in main_rails_app module (now required)
- Add app_version variable declaration to each env's cluster-addons-layer variables.tf
- Add app_version = "0.9.6-698" to each env's terraform.tfvars
- Wire app_version = var.app_version into each env's main_rails_app module call
- Update bump scripts to target env tfvars instead of the module file
- Fix macOS sed -i -e bug that was leaving variables.tf-e backup files