### PR TITLE
Stop running app Docker image version check on main branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,4 +214,7 @@ workflows:
       - validate_networking_module
       - validate_route53_domain_module
       - validate_production_aws_route53_domains
-      - validate_app_docker_image_versions
+      - validate_app_docker_image_versions:
+          filters:
+            branches:
+              ignore: main


### PR DESCRIPTION
The validate_app_docker_image_versions job diffs against origin/main to find changed versions, so it always produces no results when running on main itself. Add a branch filter to skip the job on main.