### PR TITLE
Use CIRCLE_MERGE_BASE_SHA instead of fetching origin/main for Docker image version diff

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,8 +175,7 @@ jobs:
       - run:
           name: Validate app Docker image versions exist on Docker Hub
           command: |
-            git fetch origin main
-            CHANGED_VERSIONS=$(git diff origin/main...HEAD -- terraform/env/*/aws/us-west-1/cluster-addons-layer/terraform.tfvars | grep '^+app_version' | grep -oP '"\K[^"]+' | sort -u)
+            CHANGED_VERSIONS=$(git diff ${CIRCLE_MERGE_BASE_SHA}..HEAD -- terraform/env/*/aws/us-west-1/cluster-addons-layer/terraform.tfvars | grep '^+app_version' | grep -oP '"\K[^"]+' | sort -u)
             if [ -z "${CHANGED_VERSIONS}" ]; then
               echo "No app_version changes detected, skipping Docker Hub validation"
               exit 0


### PR DESCRIPTION
Replaces the `git fetch origin main` + `git diff origin/main...HEAD` pattern with `git diff ${CIRCLE_MERGE_BASE_SHA}..HEAD`. CircleCI provides this variable as the point where the branch diverged from the default branch, so no extra network fetch is needed. Eliminates a potential source of intermittent failures from the fetch step.