### PR TITLE
Bump staging app docker image version to 0.9.6-817

### DIFF
--- a/terraform/env/staging/aws/us-west-1/cluster-addons-layer/terraform.tfvars
+++ b/terraform/env/staging/aws/us-west-1/cluster-addons-layer/terraform.tfvars
@@ -1,5 +1,5 @@
 alarm_email                    = "steven.uray@automation-caluclations.net"
-app_version                    = "0.9.6-698"
+app_version                    = "0.9.6-817"
 automation_calculator_app_host = "staging.automation-calculations.io"
 db_engine_version              = "16.13"
 tfe_base_layer_workspace_name  = "ac_app_staging_base_cluster_layer"


### PR DESCRIPTION
Bumps app_version in staging cluster-addons-layer tfvars from 0.9.6-698 to 0.9.6-817. Dev and production are unchanged.