### PR TITLE
Revert to fetching origin/main for Docker image version diff

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,7 +175,8 @@ jobs:
       - run:
           name: Validate app Docker image versions exist on Docker Hub
           command: |
-            CHANGED_VERSIONS=$(git diff ${CIRCLE_MERGE_BASE_SHA}..HEAD -- terraform/env/*/aws/us-west-1/cluster-addons-layer/terraform.tfvars | grep '^+app_version' | grep -oP '"\K[^"]+' | sort -u)
+            git fetch origin main
+            CHANGED_VERSIONS=$(git diff origin/main...HEAD -- terraform/env/*/aws/us-west-1/cluster-addons-layer/terraform.tfvars | grep '^+app_version' | grep -oP '"\K[^"]+' | sort -u)
             if [ -z "${CHANGED_VERSIONS}" ]; then
               echo "No app_version changes detected, skipping Docker Hub validation"
               exit 0


### PR DESCRIPTION
## Summary
- PR #283 switched the diff base from `origin/main` to `${CIRCLE_MERGE_BASE_SHA}`. The first build to exercise the new script (PR #284, the staging 0.9.6-817 bump) failed with exit code 1.
- Root cause is unverified, but the most likely culprit is `CIRCLE_MERGE_BASE_SHA` being empty/unset on this CircleCI integration. Combined with the `set -eo pipefail` shebang, an empty diff makes `grep` return 1 inside the command substitution and the script exits before the `if [ -z "\${CHANGED_VERSIONS}" ]` early-return runs.
- This change reverts to the previous `git fetch origin main && git diff origin/main...HEAD` approach, which worked for every prior version bump.

## Follow-up (separate PR)
- If we want to re-attempt CIRCLE_MERGE_BASE_SHA later: add a debug echo to confirm the variable is populated, fall back to fetching main when it's empty, and consider separating the diff and grep so pipefail doesn't kill the script when there's no version change.

## Test plan
- [ ] CI runs on this branch and the `validate_app_docker_image_versions` job passes (no `+app_version` lines diffed → early-return path).
- [ ] After merge, open a fresh version-bump PR (or rerun PR #284's lineage equivalent) and confirm the validation job passes against Docker Hub.