### PR TITLE
Rewrite app Docker image version check in Python

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,23 +175,8 @@ jobs:
       - run:
           name: Validate app Docker image versions exist on Docker Hub
           command: |
-            CHANGED_VERSIONS=$(git diff ${CIRCLE_MERGE_BASE_SHA}..HEAD -- terraform/env/*/aws/us-west-1/cluster-addons-layer/terraform.tfvars | grep '^+app_version' | grep -oP '"\K[^"]+' | sort -u)
-            if [ -z "${CHANGED_VERSIONS}" ]; then
-              echo "No app_version changes detected, skipping Docker Hub validation"
-              exit 0
-            fi
-            IMAGE_REPO="automationcalculationsci/automation-calculator"
-            FAILED=0
-            for VERSION in $CHANGED_VERSIONS; do
-              HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://hub.docker.com/v2/repositories/${IMAGE_REPO}/tags/${VERSION}/")
-              if [ "${HTTP_STATUS}" = "200" ]; then
-                echo "OK: ${IMAGE_REPO}:${VERSION}"
-              else
-                echo "MISSING: ${IMAGE_REPO}:${VERSION} (HTTP ${HTTP_STATUS})"
-                FAILED=1
-              fi
-            done
-            exit ${FAILED}
+            git fetch origin main
+            python3 scripts/check_app_docker_image_versions.py --base origin/main
 
 workflows:
   validate:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,7 @@ scripts/update_kubeconfigs.sh                  # Refresh kubeconfig for all envs
 scripts/launch_psql_pod.sh                     # Launch a psql pod to connect to RDS
 scripts/bump_app_docker_image_version.sh       # Bump app Docker image version in Helm values + Terraform
 scripts/bump_app_docker_image_version_branch.sh  # Same, but creates a git branch
+scripts/check_app_docker_image_versions.py     # CI: validate added app_version values exist on Docker Hub
 scripts/sort_tfvars.sh                         # Sort terraform.tfvars files alphabetically
 scripts/install_tf.sh                          # Install a specific Terraform version
 scripts/delete_first_eks_cluster.sh            # Delete the first EKS cluster (dev utility)

--- a/scripts/check_app_docker_image_versions.py
+++ b/scripts/check_app_docker_image_versions.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Check that any app_version values added in this branch exist on Docker Hub.
+
+Diffs `<base>..HEAD` over the cluster-addons-layer terraform.tfvars files,
+extracts versions added on `+app_version` lines, and checks each tag against
+the Docker Hub registry API. Exits non-zero if any tag is missing.
+
+Designed for CircleCI; runs on the standard library only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+
+TFVARS_PATHSPEC = "terraform/env/*/aws/us-west-1/cluster-addons-layer/terraform.tfvars"
+VAR_NAME = "app_version"
+IMAGE_REPO = "automationcalculationsci/automation-calculator"
+DOCKER_HUB_TAG_URL = "https://hub.docker.com/v2/repositories/{repo}/tags/{tag}/"
+HTTP_TIMEOUT_SECONDS = 15
+
+ADDED_VERSION_RE = re.compile(rf'^\+\s*{re.escape(VAR_NAME)}\s*=\s*"([^"]+)"')
+
+
+def git_diff(base: str) -> str:
+    result = subprocess.run(
+        ["git", "diff", f"{base}..HEAD", "--", TFVARS_PATHSPEC],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def added_versions(diff_text: str) -> list[str]:
+    versions: set[str] = set()
+    for line in diff_text.splitlines():
+        match = ADDED_VERSION_RE.match(line)
+        if match:
+            versions.add(match.group(1))
+    return sorted(versions)
+
+
+def tag_status(repo: str, tag: str) -> int:
+    url = DOCKER_HUB_TAG_URL.format(repo=repo, tag=tag)
+    try:
+        with urllib.request.urlopen(url, timeout=HTTP_TIMEOUT_SECONDS) as response:
+            return response.status
+    except urllib.error.HTTPError as exc:
+        return exc.code
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base",
+        default="origin/main",
+        help="Git ref to diff against (default: origin/main)",
+    )
+    args = parser.parse_args()
+
+    diff = git_diff(args.base)
+    versions = added_versions(diff)
+    if not versions:
+        print(f"No {VAR_NAME} changes detected, skipping Docker Hub validation")
+        return 0
+
+    failed = False
+    for version in versions:
+        status = tag_status(IMAGE_REPO, version)
+        if status == 200:
+            print(f"OK: {IMAGE_REPO}:{version}")
+        else:
+            print(f"MISSING: {IMAGE_REPO}:{version} (HTTP {status})")
+            failed = True
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Moves the inline bash one-liner in \`.circleci/config.yml\` into \`scripts/check_app_docker_image_versions.py\`. CircleCI now runs \`git fetch origin main && python3 scripts/check_app_docker_image_versions.py --base origin/main\`.
- Standard library only (subprocess, urllib, re, argparse). \`cimg/base:stable\` already ships Python 3, so no executor change.
- Exposes the diff base, pathspec, variable name, and image repo as named constants/CLI args, so future edits don't require touching CircleCI YAML.
- Avoids the original bash trap where a no-match \`grep\` inside a \`set -eo pipefail\` command substitution killed the script before the empty-diff early-return ran.

## Relationship to #285
- #285 reverts to the prior \`origin/main\` diff approach in bash. This PR also uses \`origin/main\` as the base, so it supersedes that revert. If this lands first, close #285; if #285 lands first, this just rewrites the same bash into Python.

## Test plan
- [x] Local: \`python3 scripts/check_app_docker_image_versions.py --base 48333bc^\` — detects \`0.9.6-817\`, hits Docker Hub, prints \`OK\`.
- [x] Local: \`python3 scripts/check_app_docker_image_versions.py --base HEAD\` — empty diff, prints the skip line and exits 0.
- [x] Local: \`tag_status('automationcalculationsci/automation-calculator', '0.0.0-doesnotexist')\` returns 404.
- [ ] CI: \`validate_app_docker_image_versions\` job passes on this branch (no app_version diff against main → early-return).
- [ ] After merge, a fresh version-bump PR's job reports \`OK: ...\` for the new tag.