### PR TITLE
Bump app docker image version to 0.9.6-822

### DIFF
--- a/helm/automation-calculator/values.yaml
+++ b/helm/automation-calculator/values.yaml
@@ -8,7 +8,7 @@ googleAnalyticsTrackingID: "G-1E2HD2B2RH"
 image:
   pullPolicy: Always
   repository: automationcalculationsci/automation-calculator
-  tag: 0.9.6-698
+  tag: 0.9.6-822
 ingress:
   annotations:
     alb.ingress.kubernetes.io/backend-protocol: HTTP

--- a/terraform/env/development/aws/us-west-1/cluster-addons-layer/terraform.tfvars
+++ b/terraform/env/development/aws/us-west-1/cluster-addons-layer/terraform.tfvars
@@ -1,5 +1,5 @@
 alarm_email                    = "steven.uray@automation-caluclations.net"
-app_version                    = "0.9.6-698"
+app_version                    = "0.9.6-822"
 automation_calculator_app_host = "development.automation-calculations.io"
 db_engine_version              = "16.13"
 tfe_base_layer_workspace_name  = "ac_app_development_base_cluster_layer"

--- a/terraform/env/production/aws/us-west-1/cluster-addons-layer/terraform.tfvars
+++ b/terraform/env/production/aws/us-west-1/cluster-addons-layer/terraform.tfvars
@@ -1,5 +1,5 @@
 alarm_email                    = "steven.uray@automation-caluclations.net"
-app_version                    = "0.9.6-698"
+app_version                    = "0.9.6-822"
 automation_calculator_app_host = "automation-calculations.io"
 db_engine_version              = "16.13"
 tfe_base_layer_workspace_name  = "ac_app_production_base_cluster_layer"

--- a/terraform/env/staging/aws/us-west-1/cluster-addons-layer/terraform.tfvars
+++ b/terraform/env/staging/aws/us-west-1/cluster-addons-layer/terraform.tfvars
@@ -1,5 +1,5 @@
 alarm_email                    = "steven.uray@automation-caluclations.net"
-app_version                    = "0.9.6-817"
+app_version                    = "0.9.6-822"
 automation_calculator_app_host = "staging.automation-calculations.io"
 db_engine_version              = "16.13"
 tfe_base_layer_workspace_name  = "ac_app_staging_base_cluster_layer"


### PR DESCRIPTION
Bumps app docker image version to 0.9.6-822 across all environments (development, staging, production) and the Helm chart values.