### PR TITLE
Restrict CI IAM role trust policy to explicit principal allowlist

### DIFF
--- a/terraform/env/development/aws/us-west-1/base-cluster-layer/main.tf
+++ b/terraform/env/development/aws/us-west-1/base-cluster-layer/main.tf
@@ -1,6 +1,7 @@
 module "ci_iam_role" {
-  environment_name = var.environment_name
-  source           = "../../../../../modules/aws/ci-iam-role"
+  environment_name       = var.environment_name
+  source                 = "../../../../../modules/aws/ci-iam-role"
+  trusted_principal_arns = var.ci_trusted_principal_arns
 }
 
 module "eks_cluster" {

--- a/terraform/env/development/aws/us-west-1/base-cluster-layer/terraform.tfvars
+++ b/terraform/env/development/aws/us-west-1/base-cluster-layer/terraform.tfvars
@@ -1,4 +1,5 @@
 ami_type                   = "AL2023_x86_64_STANDARD"
+ci_trusted_principal_arns  = []
 environment_name           = "development"
 kubernetes_cluster_version = "1.29"
 project_tag                = "automation-calculator"

--- a/terraform/env/development/aws/us-west-1/base-cluster-layer/variables.tf
+++ b/terraform/env/development/aws/us-west-1/base-cluster-layer/variables.tf
@@ -10,6 +10,12 @@ variable "aws_region" {
   type        = string
 }
 
+variable "ci_trusted_principal_arns" {
+  default     = []
+  description = "IAM principal ARNs (CI users/roles) allowed to assume the CI Terraform role. When empty, no principal can assume it."
+  type        = list(string)
+}
+
 variable "environment_name" {
   description = "The application development environment, i.e development/staging/production."
   type        = string

--- a/terraform/env/staging/aws/us-west-1/base-cluster-layer/main.tf
+++ b/terraform/env/staging/aws/us-west-1/base-cluster-layer/main.tf
@@ -1,6 +1,7 @@
 module "ci_iam_role" {
-  environment_name = var.environment_name
-  source           = "../../../../../modules/aws/ci-iam-role"
+  environment_name       = var.environment_name
+  source                 = "../../../../../modules/aws/ci-iam-role"
+  trusted_principal_arns = var.ci_trusted_principal_arns
 }
 
 module "eks_cluster" {

--- a/terraform/env/staging/aws/us-west-1/base-cluster-layer/terraform.tfvars
+++ b/terraform/env/staging/aws/us-west-1/base-cluster-layer/terraform.tfvars
@@ -1,4 +1,5 @@
 ami_type                   = "AL2023_x86_64_STANDARD"
+ci_trusted_principal_arns  = []
 environment_name           = "staging"
 kubernetes_cluster_version = "1.35"
 project_tag                = "automation-calculator"

--- a/terraform/env/staging/aws/us-west-1/base-cluster-layer/variables.tf
+++ b/terraform/env/staging/aws/us-west-1/base-cluster-layer/variables.tf
@@ -10,6 +10,12 @@ variable "aws_region" {
   type        = string
 }
 
+variable "ci_trusted_principal_arns" {
+  default     = []
+  description = "IAM principal ARNs (CI users/roles) allowed to assume the CI Terraform role. When empty, no principal can assume it."
+  type        = list(string)
+}
+
 variable "environment_name" {
   description = "The application staging environment, i.e staging/staging/production."
   type        = string

--- a/terraform/modules/aws/ci-iam-role/main.tf
+++ b/terraform/modules/aws/ci-iam-role/main.tf
@@ -4,10 +4,14 @@ locals {
   role_name   = "ac_ci_terraform_${var.environment_name}"
   policy_name = "ac_ci_terraform_${var.environment_name}"
 
+  # When no principals are listed, fall back to a sentinel in a different
+  # (nonexistent) account. The trust statement below is already scoped to this
+  # account's principals, so the sentinel can never match and the role is
+  # assumable by no one until ARNs are explicitly added.
   trusted_principal_arns = (
     length(var.trusted_principal_arns) > 0
     ? var.trusted_principal_arns
-    : ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    : ["arn:aws:iam::000000000000:root"]
   )
 }
 
@@ -16,9 +20,20 @@ data "aws_iam_policy_document" "assume_role" {
     sid     = "AllowCiPrincipalsToAssume"
     actions = ["sts:AssumeRole"]
 
+    # The account root principal only scopes trust to principals in this
+    # account; the aws:PrincipalArn condition below restricts assumption to
+    # the explicit allowlist. Matching on ARN instead of listing principals
+    # directly keeps the trust policy valid when a listed principal does not
+    # exist yet, and avoids silent invalidation if one is deleted/recreated.
     principals {
       type        = "AWS"
-      identifiers = local.trusted_principal_arns
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+
+    condition {
+      test     = "ArnEquals"
+      variable = "aws:PrincipalArn"
+      values   = local.trusted_principal_arns
     }
   }
 }

--- a/terraform/modules/aws/ci-iam-role/variables.tf
+++ b/terraform/modules/aws/ci-iam-role/variables.tf
@@ -11,6 +11,6 @@ variable "max_session_duration" {
 
 variable "trusted_principal_arns" {
   default     = []
-  description = "IAM principal ARNs (CI users/roles) allowed to assume the CI role. Defaults to the account root, which delegates access to any principal in the account that has sts:AssumeRole permission on this role."
+  description = "IAM principal ARNs (CI users/roles) in this account allowed to assume the CI role. When empty (the default), no principal can assume the role."
   type        = list(string)
 }


### PR DESCRIPTION
## Summary
- The CI role trust policy no longer falls back to the account root when `trusted_principal_arns` is empty. Previously that default let **any** IAM principal in the account with `sts:AssumeRole` permission assume the CI roles.
- The trust statement now keeps the account root as its `Principal` (which only scopes trust to this account) and adds an `aws:PrincipalArn` condition restricting assumption to the explicit allowlist. When the list is empty, a nonexistent-account sentinel (`arn:aws:iam::000000000000:root`) makes the condition unmatchable, so the role is assumable by no one until ARNs are added.
- Dev and staging env configs expose a new `ci_trusted_principal_arns` variable (currently `[]`), so granting a CI user or a local dev principal access is a tfvars-only change.

## Why the condition instead of listing principals directly
- IAM rejects trust policies that name principals that don't exist yet; matching on `aws:PrincipalArn` lets the allowlist be authored before the CI principal is created.
- Direct principal references are resolved to unique IDs, so deleting and recreating a principal silently invalidates the trust; ARN matching does not have this failure mode.
- For assumed-role sessions, `aws:PrincipalArn` evaluates to the underlying role ARN, so listing a role ARN works as expected.

## Testing
- `terraform fmt -check -recursive terraform/` passes
- `terraform validate` passes for the `ci-iam-role` module and the development `base-cluster-layer` config

🤖 Generated with [Claude Code](https://claude.com/claude-code)