### PR TITLE
Add infra_eng role and suray IAM user for human access to CI roles

### DIFF
--- a/terraform/env/development/aws/us-west-1/base-cluster-layer/main.tf
+++ b/terraform/env/development/aws/us-west-1/base-cluster-layer/main.tf
@@ -17,7 +17,14 @@ locals {
 module "ci_iam_role" {
   environment_name       = var.environment_name
   source                 = "../../../../../modules/aws/ci-iam-role"
-  trusted_principal_arns = concat(local.sso_infra_eng_role_arn_patterns, var.ci_trusted_principal_arns)
+  trusted_principal_arns = concat(local.sso_infra_eng_role_arn_patterns, [module.infra_eng_iam.role_arn], var.ci_trusted_principal_arns)
+}
+
+# Account-global human-access identities (infra_eng role + IAM user). All
+# environments share the AWS account, so these are created once, here in the
+# development workspace; other environments trust the role by its ARN.
+module "infra_eng_iam" {
+  source = "../../../../../modules/aws/infra-eng-iam-role"
 }
 
 # Per-environment IAM Identity Center access for infrastructure engineers

--- a/terraform/env/development/aws/us-west-1/base-cluster-layer/outputs.tf
+++ b/terraform/env/development/aws/us-west-1/base-cluster-layer/outputs.tf
@@ -18,6 +18,16 @@ output "environment_name" {
   value       = var.environment_name
 }
 
+output "infra_eng_role_arn" {
+  description = "The ARN of the account-global infra_eng IAM role"
+  value       = module.infra_eng_iam.role_arn
+}
+
+output "infra_eng_user_arn" {
+  description = "The ARN of the infra engineer IAM user allowed to assume the infra_eng role"
+  value       = module.infra_eng_iam.user_arn
+}
+
 output "private_eks_subnet_ids" {
   description = "The private subnet ids in the VPC"
   value       = module.networking_layer.private_eks_subnet_ids

--- a/terraform/env/staging/aws/us-west-1/base-cluster-layer/main.tf
+++ b/terraform/env/staging/aws/us-west-1/base-cluster-layer/main.tf
@@ -1,12 +1,16 @@
 data "aws_caller_identity" "current" {}
 
 locals {
+  # The infra_eng role is account-global and created by the development
+  # base-cluster-layer workspace. The CI role trust policy matches principals
+  # on aws:PrincipalArn, so referencing the ARN by naming convention is safe
+  # even before that role exists.
+  infra_eng_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/ac_infra_eng"
+
   # IAM role that Identity Center provisions for this environment's InfraEng
   # permission set. Its name carries a random suffix (and, depending on the
   # Identity Center instance region, a region path segment), so trust matches
-  # on wildcard patterns. Safe to trust before the role exists, since the CI
-  # role trust policy matches on aws:PrincipalArn rather than resolving the
-  # principal.
+  # on wildcard patterns.
   sso_permission_set_name = "InfraEng${title(var.environment_name)}"
   sso_infra_eng_role_arn_patterns = [
     "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_${local.sso_permission_set_name}_*",
@@ -17,7 +21,7 @@ locals {
 module "ci_iam_role" {
   environment_name       = var.environment_name
   source                 = "../../../../../modules/aws/ci-iam-role"
-  trusted_principal_arns = concat(local.sso_infra_eng_role_arn_patterns, var.ci_trusted_principal_arns)
+  trusted_principal_arns = concat(local.sso_infra_eng_role_arn_patterns, [local.infra_eng_role_arn], var.ci_trusted_principal_arns)
 }
 
 # Per-environment IAM Identity Center access for infrastructure engineers

--- a/terraform/modules/aws/infra-eng-iam-role/.terraform.lock.hcl
+++ b/terraform/modules/aws/infra-eng-iam-role/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.44.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:+xHWvYNFliL9ukFNIPBdqmOQ15Jtw41TN3Qv0CPxi+g=",
+    "zh:0462747d28f6dcd7b1b723bea9da1600526b7cdcf929ed4be54352d74b0746e6",
+    "zh:0c9b7e7b04050360f609ff5700d8a76227fb4ea84dac92b844d82a2013706705",
+    "zh:2877a6854edf237f9d6c66dc928294cbbcf29d3f52577fb8f232d0cfd11d5c0d",
+    "zh:3347b82e222bbfad326b79c408e53a9252b80c6c762f4dd4f4617583394f0a4e",
+    "zh:33997dbe611b5abf49c87a31f29d8f797c97421f67b71fec8aa688799511b758",
+    "zh:5d5c37375c5e776e6e8f95fb8cbd8009258618b9f51c55551a18adc09ef5814a",
+    "zh:67d6bd61c52ca5f4c37c96a76f6820c9f1902e4b83f89faddf9fd7f17ba0b160",
+    "zh:739588639fa30db7084d6939c2eb9b4dd2d7f58dbb5d5b3b2c4bda2a35dcf521",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a953797142df4245bd8f456b9e78690f501a0fff2f58552db4eb2da409cd99e9",
+    "zh:aeb8d616dd34a9f1c5048ed4cdd6d7692db93cd33a468872618d4cd38c4784aa",
+    "zh:dc8420556aca50658247b097de6734259fc3a6012ff1cf96612fca10b3982f9d",
+    "zh:f9083d6d9fb9cbdcd91e38c92f96e67223ecc7ce6d0986bd5eb8e6d52e9aa02b",
+    "zh:f9418aa1e4d29f9026aa6f521e97d085e000902ea929debbbef61135185e3ad4",
+    "zh:fb2494a6c92118055cfb2c114a4fe5c750946a1b0d6be6bf02ab3e37a091fb8b",
+  ]
+}

--- a/terraform/modules/aws/infra-eng-iam-role/main.tf
+++ b/terraform/modules/aws/infra-eng-iam-role/main.tf
@@ -1,0 +1,104 @@
+data "aws_caller_identity" "current" {}
+
+locals {
+  role_name = "ac_infra_eng"
+}
+
+# Human bootstrap identity. No access keys are managed by Terraform (so no
+# long-lived secrets land in state); the user creates their own key out of
+# band, and that key's only power is assuming the infra_eng role — all real
+# work happens on the short-lived STS tokens the role chain returns.
+resource "aws_iam_user" "infra_eng" {
+  name = var.user_name
+
+  tags = {
+    Project = "automation_calculator"
+  }
+}
+
+data "aws_iam_policy_document" "assume_infra_eng" {
+  statement {
+    sid       = "AllowAssumingInfraEngRole"
+    actions   = ["sts:AssumeRole"]
+    resources = [aws_iam_role.infra_eng.arn]
+  }
+}
+
+resource "aws_iam_policy" "assume_infra_eng" {
+  name        = "ac_assume_infra_eng"
+  description = "Allows assuming the ${local.role_name} role. The only permission human bootstrap identities carry."
+  policy      = data.aws_iam_policy_document.assume_infra_eng.json
+
+  tags = {
+    Project = "automation_calculator"
+  }
+}
+
+resource "aws_iam_user_policy_attachment" "assume_infra_eng" {
+  user       = aws_iam_user.infra_eng.name
+  policy_arn = aws_iam_policy.assume_infra_eng.arn
+}
+
+data "aws_iam_policy_document" "infra_eng_assume_role" {
+  statement {
+    sid     = "AllowInfraEngineersToAssume"
+    actions = ["sts:AssumeRole"]
+
+    # Same pattern as the ci-iam-role module: the account root principal only
+    # scopes trust to this account, and the aws:PrincipalArn condition
+    # restricts assumption to the explicit allowlist.
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+
+    condition {
+      test     = "ArnEquals"
+      variable = "aws:PrincipalArn"
+      values   = [aws_iam_user.infra_eng.arn]
+    }
+
+    dynamic "condition" {
+      for_each = var.require_mfa ? [1] : []
+      content {
+        test     = "Bool"
+        variable = "aws:MultiFactorAuthPresent"
+        values   = ["true"]
+      }
+    }
+  }
+}
+
+resource "aws_iam_role" "infra_eng" {
+  name                 = local.role_name
+  description          = "Assumed by infrastructure engineers to reach the per-environment CI Terraform roles"
+  assume_role_policy   = data.aws_iam_policy_document.infra_eng_assume_role.json
+  max_session_duration = var.max_session_duration
+
+  tags = {
+    Project = "automation_calculator"
+  }
+}
+
+data "aws_iam_policy_document" "infra_eng_permissions" {
+  statement {
+    sid       = "AssumeCiTerraformRoles"
+    actions   = ["sts:AssumeRole"]
+    resources = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/ac_ci_terraform_*"]
+  }
+}
+
+resource "aws_iam_policy" "infra_eng" {
+  name        = local.role_name
+  description = "Permissions for infrastructure engineers: assume the per-environment CI Terraform roles"
+  policy      = data.aws_iam_policy_document.infra_eng_permissions.json
+
+  tags = {
+    Project = "automation_calculator"
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "infra_eng" {
+  role       = aws_iam_role.infra_eng.name
+  policy_arn = aws_iam_policy.infra_eng.arn
+}

--- a/terraform/modules/aws/infra-eng-iam-role/outputs.tf
+++ b/terraform/modules/aws/infra-eng-iam-role/outputs.tf
@@ -1,0 +1,19 @@
+output "role_arn" {
+  description = "The ARN of the infra_eng IAM role."
+  value       = aws_iam_role.infra_eng.arn
+}
+
+output "role_name" {
+  description = "The name of the infra_eng IAM role."
+  value       = aws_iam_role.infra_eng.name
+}
+
+output "user_arn" {
+  description = "The ARN of the infra engineer IAM user."
+  value       = aws_iam_user.infra_eng.arn
+}
+
+output "user_name" {
+  description = "The name of the infra engineer IAM user."
+  value       = aws_iam_user.infra_eng.name
+}

--- a/terraform/modules/aws/infra-eng-iam-role/variables.tf
+++ b/terraform/modules/aws/infra-eng-iam-role/variables.tf
@@ -1,0 +1,17 @@
+variable "max_session_duration" {
+  default     = 3600
+  description = "Maximum session duration in seconds for the infra_eng role."
+  type        = number
+}
+
+variable "require_mfa" {
+  default     = false
+  description = "Require an MFA-authenticated session to assume the infra_eng role."
+  type        = bool
+}
+
+variable "user_name" {
+  default     = "suray"
+  description = "Name of the IAM user allowed to assume the infra_eng role."
+  type        = string
+}

--- a/terraform/modules/aws/infra-eng-iam-role/versions.tf
+++ b/terraform/modules/aws/infra-eng-iam-role/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}


### PR DESCRIPTION
> Depends on #299 (merged). This PR is the optional non-SSO fallback path: a bootstrap IAM user + infra_eng role chain for CLI access without Identity Center.

## Summary
Creates the human-access identity chain: `suray` (IAM user) → `ac_infra_eng` (role) → `ac_ci_terraform_<env>` (CI roles), where every hop is an `sts:AssumeRole` returning short-lived STS credentials.

- New account-global module `terraform/modules/aws/infra-eng-iam-role`:
  - `ac_infra_eng` role — its **only** permission is `sts:AssumeRole` on `arn:aws:iam::<acct>:role/ac_ci_terraform_*`
  - `suray` IAM user — its **only** permission is `sts:AssumeRole` on `ac_infra_eng`
  - **No access keys are managed by Terraform**, so no long-lived secrets land in TF state. The user creates one key out of band purely as a CLI bootstrap credential; everything downstream is temporary STS tokens.
  - Optional `require_mfa` variable adds an `aws:MultiFactorAuthPresent` condition to the role trust.
- Both trust edges use the account-root-principal + `aws:PrincipalArn`-condition pattern introduced in #297.
- Instantiated once in the **development** base-cluster-layer (all environments share the AWS account); its role ARN is prepended to the dev CI role's trusted principals. **Staging** trusts the role by its deterministic ARN (`.../role/ac_infra_eng`), which is safe before the role exists because trust matches on ARN instead of resolving the principal.
- Dev workspace outputs `infra_eng_role_arn` and `infra_eng_user_arn`.

## Local CLI usage after apply
```ini
# ~/.aws/config
[profile infra-eng]
role_arn = arn:aws:iam::<ACCOUNT_ID>:role/ac_infra_eng
source_profile = suray
region = us-west-1

[profile ac-ci-dev]
role_arn = arn:aws:iam::<ACCOUNT_ID>:role/ac_ci_terraform_development
source_profile = infra-eng
region = us-west-1
```

## Testing
- `terraform fmt -check -recursive terraform/` passes
- `terraform validate` passes for the new module and both dev and staging base-cluster-layer configs
- New module's `.terraform.lock.hcl` pins AWS provider 6.44.0, matching every other lock file in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)


