### PR TITLE
Add IAM Identity Center InfraEng access federated from Google Workspace

### DIFF
--- a/terraform/env/development/aws/us-west-1/base-cluster-layer/main.tf
+++ b/terraform/env/development/aws/us-west-1/base-cluster-layer/main.tf
@@ -1,14 +1,16 @@
 data "aws_caller_identity" "current" {}
 
 locals {
-  # IAM role that Identity Center provisions for the InfraEng permission set.
-  # Its name carries a random suffix (and, depending on the Identity Center
-  # instance region, a region path segment), so trust matches on wildcard
-  # patterns. Safe to trust before the role exists, since the CI role trust
-  # policy matches on aws:PrincipalArn rather than resolving the principal.
+  # IAM role that Identity Center provisions for this environment's InfraEng
+  # permission set. Its name carries a random suffix (and, depending on the
+  # Identity Center instance region, a region path segment), so trust matches
+  # on wildcard patterns. Safe to trust before the role exists, since the CI
+  # role trust policy matches on aws:PrincipalArn rather than resolving the
+  # principal.
+  sso_permission_set_name = "InfraEng${title(var.environment_name)}"
   sso_infra_eng_role_arn_patterns = [
-    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_InfraEng_*",
-    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_InfraEng_*",
+    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_${local.sso_permission_set_name}_*",
+    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_${local.sso_permission_set_name}_*",
   ]
 }
 
@@ -18,15 +20,16 @@ module "ci_iam_role" {
   trusted_principal_arns = concat(local.sso_infra_eng_role_arn_patterns, var.ci_trusted_principal_arns)
 }
 
-# Account-global IAM Identity Center access for infrastructure engineers
-# (Google Workspace federated). All environments share the AWS account, so
-# this is created once, here in the development workspace. Runs against
-# us-east-1, where the Identity Center organization instance lives. Gated
-# off until the Google Workspace identity provider is connected and the
-# user is provisioned — manual console steps.
+# Per-environment IAM Identity Center access for infrastructure engineers
+# (Google Workspace federated): each environment's workspace creates its own
+# InfraEng<Env> permission set scoped to that environment's CI role. Runs
+# against us-east-1, where the Identity Center organization instance lives.
+# Gated off until the Google Workspace identity provider is connected and
+# the user is provisioned — manual console steps.
 module "sso_infra_eng" {
-  count  = var.enable_sso_infra_eng ? 1 : 0
-  source = "../../../../../modules/aws/sso-infra-eng"
+  count            = var.enable_sso_infra_eng ? 1 : 0
+  environment_name = var.environment_name
+  source           = "../../../../../modules/aws/sso-infra-eng"
   providers = {
     aws = aws.us_east_1
   }

--- a/terraform/env/development/aws/us-west-1/base-cluster-layer/main.tf
+++ b/terraform/env/development/aws/us-west-1/base-cluster-layer/main.tf
@@ -1,7 +1,31 @@
+data "aws_caller_identity" "current" {}
+
+locals {
+  # IAM role that Identity Center provisions for the InfraEng permission set.
+  # Its name carries a random suffix (and, depending on the Identity Center
+  # instance region, a region path segment), so trust matches on wildcard
+  # patterns. Safe to trust before the role exists, since the CI role trust
+  # policy matches on aws:PrincipalArn rather than resolving the principal.
+  sso_infra_eng_role_arn_patterns = [
+    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_InfraEng_*",
+    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_InfraEng_*",
+  ]
+}
+
 module "ci_iam_role" {
   environment_name       = var.environment_name
   source                 = "../../../../../modules/aws/ci-iam-role"
-  trusted_principal_arns = var.ci_trusted_principal_arns
+  trusted_principal_arns = concat(local.sso_infra_eng_role_arn_patterns, var.ci_trusted_principal_arns)
+}
+
+# Account-global IAM Identity Center access for infrastructure engineers
+# (Google Workspace federated). All environments share the AWS account, so
+# this is created once, here in the development workspace. Gated off until
+# the Identity Center instance is enabled and the Google Workspace identity
+# provider is connected — both manual console steps.
+module "sso_infra_eng" {
+  count  = var.enable_sso_infra_eng ? 1 : 0
+  source = "../../../../../modules/aws/sso-infra-eng"
 }
 
 module "eks_cluster" {

--- a/terraform/env/development/aws/us-west-1/base-cluster-layer/main.tf
+++ b/terraform/env/development/aws/us-west-1/base-cluster-layer/main.tf
@@ -20,12 +20,16 @@ module "ci_iam_role" {
 
 # Account-global IAM Identity Center access for infrastructure engineers
 # (Google Workspace federated). All environments share the AWS account, so
-# this is created once, here in the development workspace. Gated off until
-# the Identity Center instance is enabled and the Google Workspace identity
-# provider is connected — both manual console steps.
+# this is created once, here in the development workspace. Runs against
+# us-east-1, where the Identity Center organization instance lives. Gated
+# off until the Google Workspace identity provider is connected and the
+# user is provisioned — manual console steps.
 module "sso_infra_eng" {
   count  = var.enable_sso_infra_eng ? 1 : 0
   source = "../../../../../modules/aws/sso-infra-eng"
+  providers = {
+    aws = aws.us_east_1
+  }
 }
 
 module "eks_cluster" {

--- a/terraform/env/development/aws/us-west-1/base-cluster-layer/provider.tf
+++ b/terraform/env/development/aws/us-west-1/base-cluster-layer/provider.tf
@@ -8,3 +8,17 @@ provider "aws" {
     }
   }
 }
+
+# The IAM Identity Center organization instance lives in us-east-1 (its
+# primary region); ssoadmin/identitystore API calls must target that region.
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+  default_tags {
+    tags = {
+      Environment = var.environment_name,
+      Project     = var.project_tag,
+      SourceRepo  = "https://github.com/team-automation-calculator/core-iac"
+    }
+  }
+}

--- a/terraform/env/development/aws/us-west-1/base-cluster-layer/terraform.tfvars
+++ b/terraform/env/development/aws/us-west-1/base-cluster-layer/terraform.tfvars
@@ -1,6 +1,6 @@
 ami_type                   = "AL2023_x86_64_STANDARD"
 ci_trusted_principal_arns  = []
-enable_sso_infra_eng       = false
+enable_sso_infra_eng       = true
 environment_name           = "development"
 kubernetes_cluster_version = "1.29"
 project_tag                = "automation-calculator"

--- a/terraform/env/development/aws/us-west-1/base-cluster-layer/terraform.tfvars
+++ b/terraform/env/development/aws/us-west-1/base-cluster-layer/terraform.tfvars
@@ -1,5 +1,6 @@
 ami_type                   = "AL2023_x86_64_STANDARD"
 ci_trusted_principal_arns  = []
+enable_sso_infra_eng       = false
 environment_name           = "development"
 kubernetes_cluster_version = "1.29"
 project_tag                = "automation-calculator"

--- a/terraform/env/development/aws/us-west-1/base-cluster-layer/variables.tf
+++ b/terraform/env/development/aws/us-west-1/base-cluster-layer/variables.tf
@@ -16,6 +16,12 @@ variable "ci_trusted_principal_arns" {
   type        = list(string)
 }
 
+variable "enable_sso_infra_eng" {
+  default     = false
+  description = "Create the IAM Identity Center InfraEng permission set and account assignment. Enable only after the Identity Center instance exists and the Google Workspace identity provider is connected."
+  type        = bool
+}
+
 variable "environment_name" {
   description = "The application development environment, i.e development/staging/production."
   type        = string

--- a/terraform/env/development/aws/us-west-1/base-cluster-layer/variables.tf
+++ b/terraform/env/development/aws/us-west-1/base-cluster-layer/variables.tf
@@ -18,7 +18,7 @@ variable "ci_trusted_principal_arns" {
 
 variable "enable_sso_infra_eng" {
   default     = false
-  description = "Create the IAM Identity Center InfraEng permission set and account assignment. Enable only after the Identity Center instance exists and the Google Workspace identity provider is connected."
+  description = "Create the IAM Identity Center InfraEng permission set and account assignment for this environment. Enable only after the Identity Center instance exists and the Google Workspace identity provider is connected."
   type        = bool
 }
 

--- a/terraform/env/staging/aws/us-west-1/base-cluster-layer/main.tf
+++ b/terraform/env/staging/aws/us-west-1/base-cluster-layer/main.tf
@@ -1,15 +1,16 @@
 data "aws_caller_identity" "current" {}
 
 locals {
-  # IAM role that Identity Center provisions for the InfraEng permission set,
-  # managed by the development base-cluster-layer workspace. Its name carries
-  # a random suffix (and, depending on the Identity Center instance region, a
-  # region path segment), so trust matches on wildcard patterns. Safe to
-  # trust before the role exists, since the CI role trust policy matches on
-  # aws:PrincipalArn rather than resolving the principal.
+  # IAM role that Identity Center provisions for this environment's InfraEng
+  # permission set. Its name carries a random suffix (and, depending on the
+  # Identity Center instance region, a region path segment), so trust matches
+  # on wildcard patterns. Safe to trust before the role exists, since the CI
+  # role trust policy matches on aws:PrincipalArn rather than resolving the
+  # principal.
+  sso_permission_set_name = "InfraEng${title(var.environment_name)}"
   sso_infra_eng_role_arn_patterns = [
-    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_InfraEng_*",
-    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_InfraEng_*",
+    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_${local.sso_permission_set_name}_*",
+    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_${local.sso_permission_set_name}_*",
   ]
 }
 
@@ -17,6 +18,21 @@ module "ci_iam_role" {
   environment_name       = var.environment_name
   source                 = "../../../../../modules/aws/ci-iam-role"
   trusted_principal_arns = concat(local.sso_infra_eng_role_arn_patterns, var.ci_trusted_principal_arns)
+}
+
+# Per-environment IAM Identity Center access for infrastructure engineers
+# (Google Workspace federated): each environment's workspace creates its own
+# InfraEng<Env> permission set scoped to that environment's CI role. Runs
+# against us-east-1, where the Identity Center organization instance lives.
+# Gated off until the Google Workspace identity provider is connected and
+# the user is provisioned — manual console steps.
+module "sso_infra_eng" {
+  count            = var.enable_sso_infra_eng ? 1 : 0
+  environment_name = var.environment_name
+  source           = "../../../../../modules/aws/sso-infra-eng"
+  providers = {
+    aws = aws.us_east_1
+  }
 }
 
 module "eks_cluster" {

--- a/terraform/env/staging/aws/us-west-1/base-cluster-layer/main.tf
+++ b/terraform/env/staging/aws/us-west-1/base-cluster-layer/main.tf
@@ -1,7 +1,22 @@
+data "aws_caller_identity" "current" {}
+
+locals {
+  # IAM role that Identity Center provisions for the InfraEng permission set,
+  # managed by the development base-cluster-layer workspace. Its name carries
+  # a random suffix (and, depending on the Identity Center instance region, a
+  # region path segment), so trust matches on wildcard patterns. Safe to
+  # trust before the role exists, since the CI role trust policy matches on
+  # aws:PrincipalArn rather than resolving the principal.
+  sso_infra_eng_role_arn_patterns = [
+    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_InfraEng_*",
+    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_InfraEng_*",
+  ]
+}
+
 module "ci_iam_role" {
   environment_name       = var.environment_name
   source                 = "../../../../../modules/aws/ci-iam-role"
-  trusted_principal_arns = var.ci_trusted_principal_arns
+  trusted_principal_arns = concat(local.sso_infra_eng_role_arn_patterns, var.ci_trusted_principal_arns)
 }
 
 module "eks_cluster" {

--- a/terraform/env/staging/aws/us-west-1/base-cluster-layer/provider.tf
+++ b/terraform/env/staging/aws/us-west-1/base-cluster-layer/provider.tf
@@ -8,3 +8,17 @@ provider "aws" {
     }
   }
 }
+
+# The IAM Identity Center organization instance lives in us-east-1 (its
+# primary region); ssoadmin/identitystore API calls must target that region.
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+  default_tags {
+    tags = {
+      Environment = var.environment_name,
+      Project     = var.project_tag,
+      SourceRepo  = "https://github.com/team-automation-calculator/core-iac"
+    }
+  }
+}

--- a/terraform/env/staging/aws/us-west-1/base-cluster-layer/terraform.tfvars
+++ b/terraform/env/staging/aws/us-west-1/base-cluster-layer/terraform.tfvars
@@ -1,5 +1,6 @@
 ami_type                   = "AL2023_x86_64_STANDARD"
 ci_trusted_principal_arns  = []
+enable_sso_infra_eng       = true
 environment_name           = "staging"
 kubernetes_cluster_version = "1.35"
 project_tag                = "automation-calculator"

--- a/terraform/env/staging/aws/us-west-1/base-cluster-layer/variables.tf
+++ b/terraform/env/staging/aws/us-west-1/base-cluster-layer/variables.tf
@@ -16,6 +16,12 @@ variable "ci_trusted_principal_arns" {
   type        = list(string)
 }
 
+variable "enable_sso_infra_eng" {
+  default     = false
+  description = "Create the IAM Identity Center InfraEng permission set and account assignment for this environment. Enable only after the Identity Center instance exists and the Google Workspace identity provider is connected."
+  type        = bool
+}
+
 variable "environment_name" {
   description = "The application staging environment, i.e staging/staging/production."
   type        = string

--- a/terraform/modules/aws/ci-iam-role/main.tf
+++ b/terraform/modules/aws/ci-iam-role/main.tf
@@ -30,8 +30,11 @@ data "aws_iam_policy_document" "assume_role" {
       identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
     }
 
+    # ArnLike so trusted ARNs may contain wildcards (e.g. the random suffix
+    # in Identity Center's AWSReservedSSO_* role names); exact ARNs still
+    # match identically.
     condition {
-      test     = "ArnEquals"
+      test     = "ArnLike"
       variable = "aws:PrincipalArn"
       values   = local.trusted_principal_arns
     }

--- a/terraform/modules/aws/sso-infra-eng/.terraform.lock.hcl
+++ b/terraform/modules/aws/sso-infra-eng/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.44.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:+xHWvYNFliL9ukFNIPBdqmOQ15Jtw41TN3Qv0CPxi+g=",
+    "zh:0462747d28f6dcd7b1b723bea9da1600526b7cdcf929ed4be54352d74b0746e6",
+    "zh:0c9b7e7b04050360f609ff5700d8a76227fb4ea84dac92b844d82a2013706705",
+    "zh:2877a6854edf237f9d6c66dc928294cbbcf29d3f52577fb8f232d0cfd11d5c0d",
+    "zh:3347b82e222bbfad326b79c408e53a9252b80c6c762f4dd4f4617583394f0a4e",
+    "zh:33997dbe611b5abf49c87a31f29d8f797c97421f67b71fec8aa688799511b758",
+    "zh:5d5c37375c5e776e6e8f95fb8cbd8009258618b9f51c55551a18adc09ef5814a",
+    "zh:67d6bd61c52ca5f4c37c96a76f6820c9f1902e4b83f89faddf9fd7f17ba0b160",
+    "zh:739588639fa30db7084d6939c2eb9b4dd2d7f58dbb5d5b3b2c4bda2a35dcf521",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a953797142df4245bd8f456b9e78690f501a0fff2f58552db4eb2da409cd99e9",
+    "zh:aeb8d616dd34a9f1c5048ed4cdd6d7692db93cd33a468872618d4cd38c4784aa",
+    "zh:dc8420556aca50658247b097de6734259fc3a6012ff1cf96612fca10b3982f9d",
+    "zh:f9083d6d9fb9cbdcd91e38c92f96e67223ecc7ce6d0986bd5eb8e6d52e9aa02b",
+    "zh:f9418aa1e4d29f9026aa6f521e97d085e000902ea929debbbef61135185e3ad4",
+    "zh:fb2494a6c92118055cfb2c114a4fe5c750946a1b0d6be6bf02ab3e37a091fb8b",
+  ]
+}

--- a/terraform/modules/aws/sso-infra-eng/main.tf
+++ b/terraform/modules/aws/sso-infra-eng/main.tf
@@ -10,11 +10,17 @@ data "aws_ssoadmin_instances" "this" {}
 locals {
   instance_arn      = tolist(data.aws_ssoadmin_instances.this.arns)[0]
   identity_store_id = tolist(data.aws_ssoadmin_instances.this.identity_store_ids)[0]
+
+  permission_set_name = (
+    var.permission_set_name != ""
+    ? var.permission_set_name
+    : "InfraEng${title(var.environment_name)}"
+  )
 }
 
 resource "aws_ssoadmin_permission_set" "infra_eng" {
-  name             = var.permission_set_name
-  description      = "Infrastructure engineers: assume the per-environment CI Terraform roles"
+  name             = local.permission_set_name
+  description      = "Infrastructure engineers: assume the ${var.environment_name} CI Terraform role"
   instance_arn     = local.instance_arn
   session_duration = var.session_duration
 
@@ -25,9 +31,9 @@ resource "aws_ssoadmin_permission_set" "infra_eng" {
 
 data "aws_iam_policy_document" "infra_eng" {
   statement {
-    sid       = "AssumeCiTerraformRoles"
+    sid       = "AssumeCiTerraformRole"
     actions   = ["sts:AssumeRole"]
-    resources = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/ac_ci_terraform_*"]
+    resources = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/ac_ci_terraform_${var.environment_name}"]
   }
 }
 

--- a/terraform/modules/aws/sso-infra-eng/main.tf
+++ b/terraform/modules/aws/sso-infra-eng/main.tf
@@ -1,0 +1,62 @@
+data "aws_caller_identity" "current" {}
+
+# Requires an IAM Identity Center instance to already be enabled in this
+# account and region; enabling it (and connecting the external identity
+# provider) is a manual console step with no AWS API.
+data "aws_ssoadmin_instances" "this" {}
+
+locals {
+  instance_arn      = tolist(data.aws_ssoadmin_instances.this.arns)[0]
+  identity_store_id = tolist(data.aws_ssoadmin_instances.this.identity_store_ids)[0]
+}
+
+resource "aws_ssoadmin_permission_set" "infra_eng" {
+  name             = var.permission_set_name
+  description      = "Infrastructure engineers: assume the per-environment CI Terraform roles"
+  instance_arn     = local.instance_arn
+  session_duration = var.session_duration
+
+  tags = {
+    Project = "automation_calculator"
+  }
+}
+
+data "aws_iam_policy_document" "infra_eng" {
+  statement {
+    sid       = "AssumeCiTerraformRoles"
+    actions   = ["sts:AssumeRole"]
+    resources = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/ac_ci_terraform_*"]
+  }
+}
+
+resource "aws_ssoadmin_permission_set_inline_policy" "infra_eng" {
+  inline_policy      = data.aws_iam_policy_document.infra_eng.json
+  instance_arn       = local.instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.infra_eng.arn
+}
+
+# The Identity Center user is provisioned from the external identity provider
+# (Google Workspace SCIM auto-provisioning, or created manually with the same
+# userName), not by Terraform. Looked up here so the account assignment fails
+# loudly if provisioning has not happened yet.
+data "aws_identitystore_user" "infra_eng" {
+  count             = var.user_name == "" ? 0 : 1
+  identity_store_id = local.identity_store_id
+
+  alternate_identifier {
+    unique_attribute {
+      attribute_path  = "UserName"
+      attribute_value = var.user_name
+    }
+  }
+}
+
+resource "aws_ssoadmin_account_assignment" "infra_eng" {
+  count              = var.user_name == "" ? 0 : 1
+  instance_arn       = local.instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.infra_eng.arn
+  principal_id       = data.aws_identitystore_user.infra_eng[0].user_id
+  principal_type     = "USER"
+  target_id          = data.aws_caller_identity.current.account_id
+  target_type        = "AWS_ACCOUNT"
+}

--- a/terraform/modules/aws/sso-infra-eng/main.tf
+++ b/terraform/modules/aws/sso-infra-eng/main.tf
@@ -1,8 +1,10 @@
 data "aws_caller_identity" "current" {}
 
-# Requires an IAM Identity Center instance to already be enabled in this
-# account and region; enabling it (and connecting the external identity
-# provider) is a manual console step with no AWS API.
+# Requires an IAM Identity Center instance to already exist, and the AWS
+# provider passed to this module must target the instance's primary region
+# (us-east-1 for this organization) — ssoadmin/identitystore APIs only
+# respond there. Connecting the external identity provider is a manual
+# console step with no AWS API.
 data "aws_ssoadmin_instances" "this" {}
 
 locals {

--- a/terraform/modules/aws/sso-infra-eng/outputs.tf
+++ b/terraform/modules/aws/sso-infra-eng/outputs.tf
@@ -1,0 +1,9 @@
+output "permission_set_arn" {
+  description = "The ARN of the InfraEng permission set."
+  value       = aws_ssoadmin_permission_set.infra_eng.arn
+}
+
+output "permission_set_name" {
+  description = "The name of the InfraEng permission set."
+  value       = aws_ssoadmin_permission_set.infra_eng.name
+}

--- a/terraform/modules/aws/sso-infra-eng/variables.tf
+++ b/terraform/modules/aws/sso-infra-eng/variables.tf
@@ -1,6 +1,11 @@
+variable "environment_name" {
+  description = "The application development environment, i.e development/staging/production."
+  type        = string
+}
+
 variable "permission_set_name" {
-  default     = "InfraEng"
-  description = "Name of the IAM Identity Center permission set. Also determines the AWSReservedSSO_<name>_* role name that CI role trust policies match on."
+  default     = ""
+  description = "Name of the IAM Identity Center permission set. Defaults to InfraEng<EnvironmentName>. Also determines the AWSReservedSSO_<name>_* role name that CI role trust policies match on."
   type        = string
 }
 

--- a/terraform/modules/aws/sso-infra-eng/variables.tf
+++ b/terraform/modules/aws/sso-infra-eng/variables.tf
@@ -1,0 +1,17 @@
+variable "permission_set_name" {
+  default     = "InfraEng"
+  description = "Name of the IAM Identity Center permission set. Also determines the AWSReservedSSO_<name>_* role name that CI role trust policies match on."
+  type        = string
+}
+
+variable "session_duration" {
+  default     = "PT8H"
+  description = "ISO-8601 session duration for the permission set."
+  type        = string
+}
+
+variable "user_name" {
+  default     = "steven.uray@automation-calculations.io"
+  description = "Identity Center userName (the Google Workspace email) to assign to this account with the permission set. Empty string skips the assignment."
+  type        = string
+}

--- a/terraform/modules/aws/sso-infra-eng/variables.tf
+++ b/terraform/modules/aws/sso-infra-eng/variables.tf
@@ -11,7 +11,7 @@ variable "session_duration" {
 }
 
 variable "user_name" {
-  default     = "steven.uray@automation-calculations.io"
+  default     = "steven.uray@automation-calculations.net"
   description = "Identity Center userName (the Google Workspace email) to assign to this account with the permission set. Empty string skips the assignment."
   type        = string
 }

--- a/terraform/modules/aws/sso-infra-eng/versions.tf
+++ b/terraform/modules/aws/sso-infra-eng/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}


### PR DESCRIPTION
> Merge/apply **before** #298; #298 is stacked on this branch.

## Summary
Lets `steven.uray@automation-calculations.net` sign in to AWS with their Google Workspace account and operate the CI Terraform roles on short-lived STS tokens only — no IAM user access keys anywhere in the chain.

- New module `terraform/modules/aws/sso-infra-eng`, instantiated **per environment**: each base-cluster-layer workspace creates its own `InfraEng<Env>` permission set (`InfraEngDevelopment`, `InfraEngStaging`; 8h sessions) whose **only** permission is `sts:AssumeRole` on that environment's `ac_ci_terraform_<env>` role, plus an account assignment for the Identity Center user `steven.uray@automation-calculations.net` (looked up in the identity store so the apply fails loudly if provisioning is missing). The access portal shows one role per environment.
- The organization's Identity Center instance already exists (`ssoins-7223891f36bd15c0`, org `o-ycdyoiz977`) with **primary region us-east-1**; ssoadmin/identitystore APIs only respond there, so both env configs pass an aliased us-east-1 provider to the module.
- Each environment's CI role trust policy includes wildcard patterns for only its own `AWSReservedSSO_InfraEng<Env>_*` role (random suffix, optional region path segment). Trusting the pattern before the role exists is safe because trust matches on `aws:PrincipalArn`.
- `ci-iam-role` trust condition switched `ArnEquals` → `ArnLike` to make wildcard support explicit — AWS treats the two operators identically, so exact-ARN entries behave the same.
- Both envs gate the module behind `enable_sso_infra_eng`, set to `true` in tfvars since all prerequisites are complete: Identity Center instance ✅, Google Workspace SAML identity source ✅ (verified working sign-in), user provisioned ✅.

## CLI usage after apply
```bash
aws configure sso   # start URL below, SSO region us-east-1
aws sso login --profile infra-eng-dev
```
```ini
# ~/.aws/config
[profile infra-eng-dev]
sso_session = ac
sso_account_id = 030153300357
sso_role_name = InfraEngDevelopment
region = us-west-1

[profile infra-eng-staging]
sso_session = ac
sso_account_id = 030153300357
sso_role_name = InfraEngStaging
region = us-west-1

[profile ac-ci-dev]
role_arn = arn:aws:iam::030153300357:role/ac_ci_terraform_development
source_profile = infra-eng-dev
region = us-west-1

[profile ac-ci-staging]
role_arn = arn:aws:iam::030153300357:role/ac_ci_terraform_staging
source_profile = infra-eng-staging
region = us-west-1

[sso-session ac]
sso_start_url = https://d-9067be3c25.awsapps.com/start
sso_region = us-east-1
```

## Relationship to #298
#298's `suray` IAM user + `ac_infra_eng` role remain as a non-SSO fallback path. #298 is rebased onto this branch.

## Testing
- `terraform fmt -check -recursive terraform/` passes
- `terraform validate` passes for the new module, the ci-iam-role module, and both dev and staging base-cluster-layer configs
- New module's lock file pins AWS provider 6.44.0, matching the repo
- Google → AWS SAML sign-in verified working end-to-end in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)
