### PR TITLE
Add GitHub Terraform migration plan (plans/github-terraform-migration)

### DIFF
--- a/plans/github-terraform-migration/README.md
+++ b/plans/github-terraform-migration/README.md
@@ -1,0 +1,135 @@
+# GitHub Terraform Migration Plan
+
+Bring the `team-automation-calculator` GitHub organization's assets under Terraform
+control in this repo, importing existing assets so the first apply is a pure import
+with **zero changes**.
+
+## Scope (decided)
+
+- **In scope**: the 3 repositories and their settings (`github_repository` resources only).
+- **Out of scope (this pass)**: branch protection, org settings, org memberships,
+  per-repo collaborators.
+- **Deliberately excluded**: webhooks and deploy keys — they are owned by CircleCI and
+  Terraform Cloud's VCS integration; importing them would fight those systems.
+- **Fidelity**: codify settings exactly as-is. Any policy tightening (e.g.
+  delete-branch-on-merge, protecting `development_vm`) comes later as separate PRs.
+- **Backend**: VCS-connected Terraform Cloud workspace `ac_app_global_github`,
+  org `team-automation-calculator`, following the repo's existing tf_cloud conventions.
+
+## GitHub ground truth (captured 2026-07-06 via `gh api`)
+
+Org `team-automation-calculator` (free plan). 3 public repos, all with:
+
+- `has_issues = true`, `has_wiki = true`
+- `has_projects = true`, `has_downloads = true` ← **provider defaults are false; must set explicitly**
+- `has_discussions = false`, `allow_update_branch = false`
+- `allow_merge_commit / allow_squash_merge / allow_rebase_merge = true`, `allow_auto_merge = false`
+- `delete_branch_on_merge = false`, `web_commit_signoff_required = false`, `topics = []`
+- merge/squash commit title/message settings equal provider defaults
+  (`MERGE_MESSAGE`/`PR_TITLE`, `COMMIT_OR_PR_TITLE`/`COMMIT_MESSAGES`)
+
+| Repo | default branch | description | homepage_url | vulnerability_alerts |
+|---|---|---|---|---|
+| automation-calculator | main | — | https://automation-calculations.io/ | **enabled** |
+| core-iac | main | "Infrastructure as Code base for all apps within this project, including the main one." | — | **disabled** |
+| development_vm | master | — | — | **enabled** |
+
+## Design decisions
+
+1. **Placement**: env config at `terraform/env/global/github/`; module at
+   `terraform/modules/github/repository/` (single-repo module called with `for_each`
+   over a `map(object)` variable — mirrors `terraform/modules/aws/route53-domain/` +
+   `terraform/env/production/aws/us-east-1/route53-domains/`).
+2. **Workspace bootstrap**: extend `terraform/modules/tf_cloud/tf_cloud_workspaces/`
+   with a count-gated `tfe_workspace.github_tfe_workspace`
+   (`enable_github_workspace`, default `false`) — same precedent as
+   `enable_route53_domains_workspace`. Enabled only from
+   `terraform/env/production/tf_cloud/`. Workspace name `ac_app_global_github`, tags
+   `["automation-calculator", "global"]`, `terraform_version` from
+   `var.tfe_workspace_tf_version` ("1.11"), **`auto_apply = false` hardcoded**
+   (org-critical), `vcs_repo` + `working_directory`/`trigger_prefixes` like the
+   other workspaces.
+3. **Provider/auth**: `integrations/github` `~> 6.0` (matches the AWS `~> 6.0`
+   convention). Reuse the existing sensitive TF variable literally named
+   `TF_VAR_GITHUB_TOKEN`:
+   `provider "github" { owner = "team-automation-calculator", token = var.TF_VAR_GITHUB_TOKEN }`.
+   The existing TFC variable set gets attached to the new workspace — zero new
+   secrets. **Precondition**: that token must have admin on all 3 repos.
+4. **Import mechanism**: Terraform `import` blocks in
+   `terraform/env/global/github/import.tf` targeting
+   `module.github_repositories["<name>"].github_repository.this` with
+   `id = "<repo-name>"` — same shape as the existing `route53-domains/import.tf`.
+   Removed in a cleanup PR after apply.
+5. **Backend**: `backend "remote"` block in the env config's `versions.tf` pointing
+   at workspace `ac_app_global_github` (route53-domains precedent). CI validates
+   without backend credentials.
+6. **Zero-diff guardrails on `github_repository`**: set explicitly
+   `has_projects = true`, `has_downloads = true`, and per-repo
+   `vulnerability_alerts` (all differ from provider defaults or are non-computed —
+   omitting `vulnerability_alerts` would make Terraform disable Dependabot alerts).
+   Omit `security_and_analysis` (Optional+Computed; free-plan 422 risk),
+   `auto_init`/template args (create-only), deprecated `private`, and `topics`
+   (empty; Optional+Computed). **Default branch is intentionally unmanaged**
+   (provider v6 dropped it from `github_repository`; `development_vm`'s `master`
+   causes no drift).
+7. **Destroy safety**: `archive_on_destroy = true` +
+   `lifecycle { prevent_destroy = true }` in the module. Removing a repo from the
+   tfvars map errors at plan time; deliberate removal requires editing the module
+   lifecycle or `terraform state rm`.
+
+## File tree (new ✚ / modified ✎)
+
+```
+plans/github-terraform-migration/                              ✚ this folder
+terraform/modules/github/repository/                           ✚ main.tf variables.tf outputs.tf versions.tf .terraform.lock.hcl
+terraform/env/global/github/                                   ✚ main.tf variables.tf provider.tf versions.tf
+                                                               ✚ terraform.tfvars import.tf(temp) outputs.tf .terraform.lock.hcl
+terraform/modules/tf_cloud/tf_cloud_workspaces/main.tf         ✎ + github workspace
+terraform/modules/tf_cloud/tf_cloud_workspaces/variables.tf    ✎ + 3 vars (alphabetized)
+terraform/env/production/tf_cloud/main.tf                      ✎ pass-through
+terraform/env/production/tf_cloud/variables.tf                 ✎ + 3 vars
+terraform/env/production/tf_cloud/terraform.tfvars             ✎ enable + working dir
+.circleci/config.yml                                           ✎ + validate jobs (github module, global/github env, missing ci-iam-role)
+CLAUDE.md                                                      ✎ layout tree, provider table (+ GitHub ~> 6.0), unmanaged-attrs note
+```
+
+## Phase / PR sequence
+
+Every PR: branch + `gh` draft PR, never push main. Run
+`terraform fmt -recursive terraform/` before every commit.
+
+| Phase | PR | Task file | Summary |
+|---|---|---|---|
+| 0 | PR 1 | (this folder) | Commit the plan + task files |
+| 1 | — | [task-01](task-01-capture-github-state.md) | Ground truth captured (done); verify token admin rights |
+| 2 | PR 2 | [task-02](task-02-tf-cloud-workspace.md) | TFC workspace bootstrap via tf_cloud module |
+| 3 | PR 3 | [task-03](task-03-github-module-and-env-config.md), [task-04](task-04-ci-validate-jobs.md) | GitHub module + env config + import blocks + CI jobs |
+| 4 | apply | [task-05](task-05-import-plan-and-apply.md) | Speculative-plan gate, merge, manual apply |
+| 5 | PR 4 | [task-06](task-06-cleanup-and-docs.md) | Remove import.tf, update docs |
+
+## Verification
+
+1. PR 3 speculative plan: exactly **"3 to import, 0 to add, 0 to change, 0 to destroy"** (hard merge gate).
+2. Post-apply: queue a fresh TFC plan → "No changes. Your infrastructure matches the configuration."
+3. PR 4 speculative plan → "No changes."
+4. CI green including the new validate jobs.
+5. Smoke test: toggle `has_wiki` on one repo in the GitHub UI, queue a plan, confirm
+   Terraform detects the drift, revert in the UI.
+
+## Rollback
+
+- Pre-apply: discard the TFC run.
+- Post-apply: `terraform state rm 'module.github_repositories'` (state ops work on
+  VCS workspaces with `TFE_TOKEN`) — imports made no GitHub-side changes, so removal
+  fully reverts Terraform's involvement.
+
+## Known risks / gotchas
+
+- **Perpetual-drift arguments**: `has_projects`, `has_downloads`,
+  `vulnerability_alerts` — must come from captured values, never provider defaults.
+- **Workspace-name mismatch precedent**: route53-domains' backend says
+  `ac_app_route53_domain_production` while the module creates
+  `ac_app_production_route53_domains` — a workspace was renamed manually. Confirm the
+  actual TFC workspace name matches the backend block before PR 3.
+- Token rotation in the TFC variable set now also breaks GitHub plans, not just VCS
+  connections — noted in docs (task-06).

--- a/plans/github-terraform-migration/task-01-capture-github-state.md
+++ b/plans/github-terraform-migration/task-01-capture-github-state.md
@@ -1,0 +1,46 @@
+# Task 01 — Capture GitHub ground truth & verify token
+
+**Status: mostly done (2026-07-06).** Captured values are recorded in
+[README.md](README.md) "GitHub ground truth". Re-run the capture if significant time
+passes before task-03 executes, since UI changes would break the zero-diff gate.
+
+## Remaining step: verify the TFC token has admin on all repos
+
+The workspace will authenticate with the token stored in the TFC variable set as
+`TF_VAR_GITHUB_TOKEN`. Managing repo settings requires admin permission on each repo.
+
+With that token (NOT your personal gh session):
+
+```bash
+for repo in automation-calculator core-iac development_vm; do
+  curl -s -H "Authorization: Bearer $TOKEN" \
+    https://api.github.com/repos/team-automation-calculator/$repo \
+    | jq '{repo: .name, admin: .permissions.admin}'
+done
+```
+
+All three must report `admin: true`. If not, mint a classic PAT with `repo` scope
+from an org owner (stevenuray) and update the variable set.
+
+## Re-capture commands (if needed)
+
+```bash
+for repo in automation-calculator core-iac development_vm; do
+  gh api repos/team-automation-calculator/$repo --jq \
+    '{name, description, homepage, visibility, has_issues, has_wiki, has_projects,
+      has_downloads, has_discussions, allow_squash_merge, allow_merge_commit,
+      allow_rebase_merge, allow_auto_merge, allow_update_branch,
+      delete_branch_on_merge, web_commit_signoff_required, topics,
+      merge_commit_title, merge_commit_message, squash_merge_commit_title,
+      squash_merge_commit_message}'
+  # vulnerability alerts: 204 = enabled, 404 = disabled
+  gh api repos/team-automation-calculator/$repo/vulnerability-alerts \
+    >/dev/null 2>&1 && echo "vulnerability_alerts: enabled" \
+    || echo "vulnerability_alerts: disabled"
+done
+```
+
+## Acceptance criteria
+
+- [ ] Token in the TFC variable set confirmed admin on all 3 repos
+- [ ] Captured values in README.md confirmed current (re-run if stale)

--- a/plans/github-terraform-migration/task-02-tf-cloud-workspace.md
+++ b/plans/github-terraform-migration/task-02-tf-cloud-workspace.md
@@ -1,0 +1,91 @@
+# Task 02 — Bootstrap the `ac_app_global_github` TFC workspace
+
+Delegatable to an agent. One PR (PR 2 in the sequence), then a manual TFC apply +
+one manual TFC console step.
+
+## Context
+
+Workspaces are created by `terraform/modules/tf_cloud/tf_cloud_workspaces/`, called
+from per-env `terraform/env/<env>/tf_cloud/` configs. The count-gated
+`route53_domains_tfe_workspace` resource in the module (gated by
+`enable_route53_domains_workspace`, enabled only in production tfvars) is the exact
+precedent to copy.
+
+## Changes
+
+### 1. `terraform/modules/tf_cloud/tf_cloud_workspaces/main.tf`
+
+Add (mirroring the route53 workspace resource):
+
+```hcl
+resource "tfe_workspace" "github_tfe_workspace" {
+  count             = var.enable_github_workspace ? 1 : 0
+  name              = "ac_app_global_github"
+  organization      = var.tf_cloud_organization_name
+  auto_apply        = false # org-critical: always require manual confirm
+  tag_names         = ["automation-calculator", "global"]
+  terraform_version = var.tfe_workspace_tf_version
+  trigger_prefixes  = concat([var.github_working_directory], var.github_module_directories)
+
+  vcs_repo {
+    identifier     = var.tf_cloud_workspace_vcs_repo_identifier
+    oauth_token_id = var.tfe_oauth_client_token_id
+  }
+
+  working_directory = var.github_working_directory
+}
+```
+
+Note `auto_apply` is hardcoded `false`, NOT `var.auto_apply`. Note tags use literal
+`"global"`, not `var.environment_name`.
+
+### 2. `terraform/modules/tf_cloud/tf_cloud_workspaces/variables.tf`
+
+Add, keeping the file alphabetized (there is a `scripts/sort_tfvars.sh` convention;
+variables.tf is hand-sorted):
+
+- `enable_github_workspace` — bool, default `false`, description noting it should be
+  enabled from exactly one env (production) since the workspace is global
+- `github_module_directories` — list(string), default
+  `["terraform/modules/github/repository"]`
+- `github_working_directory` — string, default `""`
+
+### 3. `terraform/env/production/tf_cloud/`
+
+- `main.tf`: pass the three new vars to the module call
+- `variables.tf`: declare the three vars (alphabetized, with descriptions/types,
+  same defaults)
+- `terraform.tfvars`: set `enable_github_workspace = true` and
+  `github_working_directory = "terraform/env/global/github"` (keep file alphabetized)
+
+## Before committing
+
+```bash
+terraform fmt -recursive terraform/
+```
+
+No provider changes, so lock files should not change (TFE pinned 0.68.2).
+
+## PR
+
+Branch + draft PR via `gh` (never push main, never use hub). Title:
+"Add global GitHub management TFC workspace (bootstrap for GitHub TF migration)".
+Link `plans/github-terraform-migration/README.md` in the body.
+
+## After merge (manual, human-in-the-loop)
+
+1. Queue/confirm the run in the **production tf_cloud bootstrap workspace** in TFC
+   (it is not auto-applied). This creates `ac_app_global_github`.
+2. In the TFC console: attach the existing variable set containing
+   `TF_VAR_GITHUB_TOKEN` (and `TFE_TOKEN`) to `ac_app_global_github`.
+3. Confirm the workspace's exact name is `ac_app_global_github` — the backend block
+   in task-03 must match it verbatim (route53 has a rename-mismatch precedent).
+4. The working directory `terraform/env/global/github` doesn't exist on main yet —
+   harmless; no runs will trigger until task-03 merges.
+
+## Acceptance criteria
+
+- [ ] CI validate jobs green (fmt + validate)
+- [ ] Plan in production tf_cloud workspace shows exactly 1 workspace to add,
+      nothing changed/destroyed
+- [ ] `ac_app_global_github` exists in TFC with the variable set attached

--- a/plans/github-terraform-migration/task-03-github-module-and-env-config.md
+++ b/plans/github-terraform-migration/task-03-github-module-and-env-config.md
@@ -1,0 +1,220 @@
+# Task 03 — GitHub repository module + global env config + import blocks
+
+Delegatable to an agent. Part of PR 3 (together with task-04's CI changes).
+Depends on: task-01 (captured values + token verified), task-02 (workspace exists).
+
+## Context
+
+- Pattern to mirror: `terraform/modules/aws/route53-domain/` (single-resource module)
+  called with `for_each` from
+  `terraform/env/production/aws/us-east-1/route53-domains/main.tf`, with import
+  blocks in `import.tf` addressing `module.x["key"].resource.this`.
+- Module style template: `terraform/modules/aws/ci-iam-role/` — `versions.tf` with
+  `required_version = ">= 1.5.7"`, alphabetized `variables.tf` with descriptions +
+  types, populated `outputs.tf` with descriptions, committed `.terraform.lock.hcl`.
+- Captured ground truth: see `plans/github-terraform-migration/README.md`.
+
+## New files
+
+### `terraform/modules/github/repository/`
+
+`versions.tf`:
+
+```hcl
+terraform {
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.0"
+    }
+  }
+}
+```
+
+`main.tf`:
+
+```hcl
+resource "github_repository" "this" {
+  allow_auto_merge            = var.allow_auto_merge
+  allow_merge_commit          = var.allow_merge_commit
+  allow_rebase_merge          = var.allow_rebase_merge
+  allow_squash_merge          = var.allow_squash_merge
+  allow_update_branch         = var.allow_update_branch
+  archive_on_destroy          = true
+  delete_branch_on_merge      = var.delete_branch_on_merge
+  description                 = var.description
+  has_downloads               = var.has_downloads
+  has_issues                  = var.has_issues
+  has_projects                = var.has_projects
+  has_wiki                    = var.has_wiki
+  homepage_url                = var.homepage_url
+  name                        = var.name
+  visibility                  = var.visibility
+  vulnerability_alerts        = var.vulnerability_alerts
+  web_commit_signoff_required = var.web_commit_signoff_required
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+```
+
+Deliberately OMIT: `security_and_analysis` (Optional+Computed; free-plan 422 risk),
+`auto_init` / `gitignore_template` / `license_template` / `template` (create-only),
+deprecated `private`, `topics` (all repos have none; Optional+Computed),
+`default_branch` (not in provider v6; default branches intentionally unmanaged),
+merge/squash commit title/message args (all repos match provider defaults).
+
+`variables.tf`: one variable per argument above, alphabetized, each with
+`description` + `type`. Sensible defaults matching org-wide reality
+(`visibility = "public"`, `has_issues = true`, `has_wiki = true`,
+`has_projects = true`, `has_downloads = true`, allow_* merge flags `true`,
+`allow_auto_merge = false`, `allow_update_branch = false`,
+`delete_branch_on_merge = false`, `web_commit_signoff_required = false`,
+`description = null`, `homepage_url = null`). `vulnerability_alerts` and `name`
+have NO default (force explicit values).
+
+`outputs.tf`: `repository_name`, `full_name`, `node_id`, `html_url` — each with a
+description.
+
+### `terraform/env/global/github/`
+
+`versions.tf`:
+
+```hcl
+terraform {
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.0"
+    }
+  }
+
+  backend "remote" {
+    hostname     = "app.terraform.io"
+    organization = "team-automation-calculator"
+
+    workspaces {
+      name = "ac_app_global_github"
+    }
+  }
+}
+```
+
+`provider.tf`:
+
+```hcl
+provider "github" {
+  owner = "team-automation-calculator"
+  token = var.TF_VAR_GITHUB_TOKEN
+}
+```
+
+`variables.tf`:
+
+```hcl
+variable "repositories" {
+  description = "GitHub repositories to manage, keyed by repository name."
+  type = map(object({
+    description          = optional(string)
+    homepage_url         = optional(string)
+    vulnerability_alerts = bool
+  }))
+}
+
+variable "TF_VAR_GITHUB_TOKEN" {
+  description = "GitHub token with admin access to org repositories. Supplied by the TFC variable set."
+  sensitive   = true
+  type        = string
+}
+```
+
+(Only per-repo-varying settings go in the object; org-wide-uniform flags ride on the
+module defaults. If a future repo diverges, promote that setting into the object.)
+
+`main.tf`:
+
+```hcl
+module "github_repositories" {
+  for_each = var.repositories
+  source   = "../../../modules/github/repository"
+
+  description          = each.value.description
+  homepage_url         = each.value.homepage_url
+  name                 = each.key
+  vulnerability_alerts = each.value.vulnerability_alerts
+}
+```
+
+`terraform.tfvars` (from captured ground truth — README.md):
+
+```hcl
+repositories = {
+  "automation-calculator" = {
+    description          = null
+    homepage_url         = "https://automation-calculations.io/"
+    vulnerability_alerts = true
+  }
+  "core-iac" = {
+    description          = "Infrastructure as Code base for all apps within this project, including the main one."
+    homepage_url         = null
+    vulnerability_alerts = false
+  }
+  "development_vm" = {
+    description          = null
+    homepage_url         = null
+    vulnerability_alerts = true
+  }
+}
+```
+
+`import.tf` (TEMPORARY — removed in task-06):
+
+```hcl
+import {
+  to = module.github_repositories["automation-calculator"].github_repository.this
+  id = "automation-calculator"
+}
+
+import {
+  to = module.github_repositories["core-iac"].github_repository.this
+  id = "core-iac"
+}
+
+import {
+  to = module.github_repositories["development_vm"].github_repository.this
+  id = "development_vm"
+}
+```
+
+`outputs.tf`: map of repo name → html_url from the module instances.
+
+## Lock files
+
+```bash
+cd terraform/modules/github/repository && terraform init
+cd ../../../env/global/github && terraform init -backend=false
+terraform providers lock -platform=linux_amd64 -platform=darwin_arm64
+```
+
+(TFC runs on linux_amd64; local dev is darwin_arm64.) Commit both
+`.terraform.lock.hcl` files. Do NOT commit `.terraform/` directories.
+
+## Before committing
+
+```bash
+terraform fmt -recursive terraform/
+```
+
+## Acceptance criteria
+
+- [ ] `terraform validate` passes in both new dirs (module: plain init;
+      env config: `init -backend=false`)
+- [ ] Lock files committed for both dirs, covering linux_amd64 + darwin_arm64
+- [ ] Combined with task-04 in one draft PR via `gh`
+- [ ] TFC speculative plan on the PR: **"3 to import, 0 to add, 0 to change,
+      0 to destroy"** — iterate on arguments until true (task-05 gates the merge)

--- a/plans/github-terraform-migration/task-04-ci-validate-jobs.md
+++ b/plans/github-terraform-migration/task-04-ci-validate-jobs.md
@@ -1,0 +1,39 @@
+# Task 04 — CircleCI validate jobs for the new Terraform directories
+
+Delegatable to an agent. Ships in the same PR as task-03 (PR 3).
+
+## Context
+
+`.circleci/config.yml` uses the `circleci/terraform@3.1` orb with hardcoded
+per-directory jobs: each terraform dir gets a job running `terraform/fmt` then
+`terraform/validate` with `path: <dir>`, plus an entry under
+`workflows.validate.jobs`. There is no dynamic discovery.
+
+Known gap: `terraform/modules/aws/ci-iam-role` (added in commit dc1d3be) has **no**
+validate job — fix it here since we're already editing the file, and call it out in
+the PR description.
+
+## Changes to `.circleci/config.yml`
+
+Copy the shape of an existing module-validate job (e.g. the route53-domain or
+tf_cloud_workspaces one) for three new jobs:
+
+1. `validate_github_repository_module` — `path: terraform/modules/github/repository`
+2. `validate_global_github_env` — `path: terraform/env/global/github`
+3. `validate_ci_iam_role_module` — `path: terraform/modules/aws/ci-iam-role`
+   (the pre-existing gap)
+
+Add all three to the `workflows.validate.jobs` list, keeping whatever ordering
+convention the file uses (module jobs grouped with module jobs, env jobs with env
+jobs).
+
+Note: the env-config job validates a dir with a `backend "remote"` block and no TFC
+credentials. Check how existing env-config validate jobs handle this (they validate
+fine because the orb's validate step initializes with `-backend=false` or
+equivalent); mirror exactly what the existing env jobs do.
+
+## Acceptance criteria
+
+- [ ] Three new jobs defined and wired into `workflows.validate.jobs`
+- [ ] CI green on the PR, including all pre-existing jobs
+- [ ] PR description mentions the ci-iam-role gap fix

--- a/plans/github-terraform-migration/task-05-import-plan-and-apply.md
+++ b/plans/github-terraform-migration/task-05-import-plan-and-apply.md
@@ -1,0 +1,59 @@
+# Task 05 — Speculative-plan gate, merge, and manual import apply
+
+Human-in-the-loop task (TFC console + PR review). Gates the merge of PR 3
+(task-03 + task-04).
+
+## Gate: speculative plan on PR 3
+
+Opening/updating PR 3 triggers a speculative plan in `ac_app_global_github`
+(VCS-connected workspace). The plan MUST read exactly:
+
+```
+Plan: 3 to import, 0 to add, 0 to change, 0 to destroy.
+```
+
+If it shows changes:
+
+1. Read the diff per attribute — each mismatch means the config value doesn't match
+   GitHub's actual state.
+2. Fix `terraform.tfvars` / module defaults to match reality (do NOT change GitHub
+   to match the config — fidelity is as-is).
+3. Push the fix; re-check the new speculative plan.
+4. If an attribute won't converge (provider quirk), consider omitting it if it is
+   Optional+Computed, and document the exclusion in the module.
+
+Common suspects if drift appears: `vulnerability_alerts`, `has_projects`,
+`has_downloads`, `security_and_analysis` (should be omitted), merge-commit
+title/message settings.
+
+## Failure modes
+
+- **401/403 in plan**: variable set not attached to the workspace, or token lacks
+  admin — revisit task-02 step 2 / task-01 verification.
+- **"workspace not found" on backend**: backend block name doesn't match the actual
+  TFC workspace name — compare with TFC console (route53 rename precedent).
+- **Import errors ("resource does not exist")**: import `id` must be the bare repo
+  name (provider owner supplies the org).
+
+## Merge + apply
+
+1. Merge PR 3 once the gate passes and CI is green.
+2. The merge triggers a plan in `ac_app_global_github`; `auto_apply` is false —
+   **manually confirm the apply** in the TFC console.
+3. Post-apply verification: queue a fresh plan → must say
+   "No changes. Your infrastructure matches the configuration."
+4. Optional smoke test: toggle `has_wiki` on one repo in the GitHub UI, queue a
+   plan, confirm Terraform reports 1 change, revert the toggle in the UI, re-plan
+   to zero.
+
+## Rollback
+
+- Pre-apply: discard the run.
+- Post-apply: `terraform state rm 'module.github_repositories'` (works on VCS
+  workspaces with TFE_TOKEN set locally) — imports made no GitHub-side changes.
+
+## Acceptance criteria
+
+- [ ] Speculative plan showed exactly 3 imports, 0 changes before merge
+- [ ] Apply confirmed; state contains the 3 repositories
+- [ ] Fresh post-apply plan shows "No changes"

--- a/plans/github-terraform-migration/task-06-cleanup-and-docs.md
+++ b/plans/github-terraform-migration/task-06-cleanup-and-docs.md
@@ -1,0 +1,43 @@
+# Task 06 — Cleanup import blocks + documentation updates
+
+Delegatable to an agent. One PR (PR 4). Depends on: task-05 apply completed.
+
+## Changes
+
+### 1. Remove the temporary import blocks
+
+Delete `terraform/env/global/github/import.tf`. The import blocks are one-shot;
+after the apply they are dead weight. (Note: `route53-domains/import.tf` was left in
+place historically — optionally remove it in this PR too; ask the user first.)
+
+### 2. `CLAUDE.md` updates
+
+- **Repository Layout tree**: add `terraform/modules/github/repository/` and
+  `terraform/env/global/github/` with one-line comments.
+- **Provider Versions table**: add row `GitHub | ~> 6.0 | ~> 6.0`.
+- **Layered Apply Order**: note the global GitHub workspace
+  (`ac_app_global_github`, bootstrapped from production tf_cloud, auto_apply off).
+- Add a short "GitHub org management" note:
+  - default branches are intentionally unmanaged (provider v6 dropped
+    `default_branch` from `github_repository`)
+  - webhooks/deploy keys intentionally unmanaged (CircleCI/TFC own them)
+  - repos are protected by `archive_on_destroy` + `prevent_destroy`; removing one
+    from tfvars errors at plan time by design
+  - rotating the token in the TFC variable set now also affects GitHub plans, not
+    just the VCS connection
+
+### 3. `README.md` (optional)
+
+Extend the TFC setup steps to mention attaching the variable set to
+`ac_app_global_github`.
+
+## Verification
+
+- Speculative plan on this PR: "No changes."
+- CI green.
+
+## Acceptance criteria
+
+- [ ] `import.tf` removed
+- [ ] CLAUDE.md layout tree, provider table, and notes updated
+- [ ] Speculative plan shows "No changes"


### PR DESCRIPTION
## What

Migration plan (docs only, no Terraform changes yet) to bring the org's GitHub assets under Terraform control, importing existing assets where practical. This is Phase 0 / PR 1 of the sequence described in the plan.

## Scope decided

- **In**: the 3 repositories + their settings (`github_repository` only), imported exactly as-is (zero-diff gate)
- **Out (this pass)**: branch protection, org settings, memberships/collaborators
- **Excluded on purpose**: webhooks & deploy keys (owned by CircleCI / TFC VCS integration)

## Approach highlights

- New VCS-connected TFC workspace `ac_app_global_github` (auto_apply off), bootstrapped by extending `tf_cloud_workspaces` with a count-gated workspace — same precedent as route53-domains
- Single-repo module `terraform/modules/github/repository` called with `for_each` from `terraform/env/global/github/`, import blocks per repo (route53-domains `import.tf` pattern)
- Auth reuses the existing `TF_VAR_GITHUB_TOKEN` TFC variable set — no new secrets
- GitHub ground truth captured 2026-07-06 (incl. drift traps: `has_projects`/`has_downloads` true everywhere, per-repo `vulnerability_alerts`)
- Merge gate for the import PR: speculative plan must read **"3 to import, 0 to add, 0 to change, 0 to destroy"**

## Contents

- `plans/github-terraform-migration/README.md` — full plan: decisions, file tree, phases, verification, rollback, risks
- `task-01`…`task-06` — self-contained delegatable task files (capture/verify token, TFC workspace bootstrap, module + env config + imports, CI validate jobs incl. the missing ci-iam-role job, plan/apply gate, cleanup + docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)