### PR TITLE
Grant CI Terraform role EKS cluster access via access entries (dev + staging)

### DIFF
--- a/terraform/env/development/aws/us-west-1/base-cluster-layer/main.tf
+++ b/terraform/env/development/aws/us-west-1/base-cluster-layer/main.tf
@@ -42,6 +42,21 @@ module "eks_cluster" {
   cluster_version  = var.kubernetes_cluster_version
   vpc_id           = module.networking_layer.vpc.id
   ami_type         = var.ami_type
+
+  # Grants the CI Terraform role kubectl/Helm access to the cluster API.
+  # Human InfraEng access flows through the same role: SSO users assume it
+  # (see ci_iam_role trust policy), so no per-user entries are needed.
+  access_entries = {
+    ci_terraform = {
+      principal_arn = module.ci_iam_role.role_arn
+      policy_associations = {
+        cluster_admin = {
+          policy_arn   = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+          access_scope = { type = "cluster" }
+        }
+      }
+    }
+  }
 }
 
 module "networking_layer" {

--- a/terraform/env/staging/aws/us-west-1/base-cluster-layer/main.tf
+++ b/terraform/env/staging/aws/us-west-1/base-cluster-layer/main.tf
@@ -47,6 +47,21 @@ module "eks_cluster" {
     max_size     = 2
     min_size     = 1
   }
+
+  # Grants the CI Terraform role kubectl/Helm access to the cluster API.
+  # Human InfraEng access flows through the same role: SSO users assume it
+  # (see ci_iam_role trust policy), so no per-user entries are needed.
+  access_entries = {
+    ci_terraform = {
+      principal_arn = module.ci_iam_role.role_arn
+      policy_associations = {
+        cluster_admin = {
+          policy_arn   = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+          access_scope = { type = "cluster" }
+        }
+      }
+    }
+  }
 }
 
 module "networking_layer" {

--- a/terraform/modules/aws/base-cluster-layer/main.tf
+++ b/terraform/modules/aws/base-cluster-layer/main.tf
@@ -2,6 +2,7 @@ module "app_eks_cluster" {
   name                   = "ac_app_${var.environment_name}"
   kubernetes_version     = var.cluster_version
   endpoint_public_access = true
+  access_entries         = var.access_entries
 
   eks_managed_node_groups = {
     primary = {

--- a/terraform/modules/aws/base-cluster-layer/variables.tf
+++ b/terraform/modules/aws/base-cluster-layer/variables.tf
@@ -1,3 +1,9 @@
+variable "access_entries" {
+  default     = {}
+  description = "EKS access entries granting IAM principals access to the cluster API, passed through to the EKS module. Map of entries keyed by a static name, each with principal_arn and optional policy_associations."
+  type        = any
+}
+
 variable "ami_id" {
   default     = null
   description = "The custom AMI ID to use for the EKS node group. If set, this will override the AMI type."


### PR DESCRIPTION
## Summary
- Add an `access_entries` pass-through input to the `base-cluster-layer` module, forwarded to the terraform-aws-modules/eks module.
- Wire the `ac_ci_terraform_<env>` CI role into dev and staging clusters with `AmazonEKSClusterAdminPolicy` (cluster-scoped).

## Why
The CI role's IAM policy includes `eks:*`, so `aws eks update-kubeconfig` succeeds — but nothing granted it Kubernetes API access, so every `kubectl` call returned `Unauthorized`. EKS access entries close that gap. Human InfraEng access flows through the same role (SSO users assume it per the CI role trust policy), so no per-user entries are needed.

Production is left unwired since the CI role module isn't provisioned there yet.

## Validation
- `terraform fmt -check -recursive terraform/` passes
- `terraform validate` passes for the module and both env configs (init with `-backend=false`)

Apply is additive-only: one `aws_eks_access_entry` + one `aws_eks_access_policy_association` per environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)