### PR TITLE
Add read-only variants of the CI Terraform role and InfraEng permission set

### DIFF
--- a/terraform/env/development/aws/us-west-1/base-cluster-layer/main.tf
+++ b/terraform/env/development/aws/us-west-1/base-cluster-layer/main.tf
@@ -7,17 +7,23 @@ locals {
   # on wildcard patterns. Safe to trust before the role exists, since the CI
   # role trust policy matches on aws:PrincipalArn rather than resolving the
   # principal.
-  sso_permission_set_name = "InfraEng${title(var.environment_name)}"
+  sso_permission_set_name           = "InfraEng${title(var.environment_name)}"
+  sso_permission_set_name_read_only = "InfraEng${title(var.environment_name)}ReadOnly"
   sso_infra_eng_role_arn_patterns = [
     "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_${local.sso_permission_set_name}_*",
     "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_${local.sso_permission_set_name}_*",
   ]
+  sso_infra_eng_read_only_role_arn_patterns = [
+    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_${local.sso_permission_set_name_read_only}_*",
+    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_${local.sso_permission_set_name_read_only}_*",
+  ]
 }
 
 module "ci_iam_role" {
-  environment_name       = var.environment_name
-  source                 = "../../../../../modules/aws/ci-iam-role"
-  trusted_principal_arns = concat(local.sso_infra_eng_role_arn_patterns, var.ci_trusted_principal_arns)
+  environment_name                 = var.environment_name
+  read_only_trusted_principal_arns = concat(local.sso_infra_eng_read_only_role_arn_patterns, var.ci_read_only_trusted_principal_arns)
+  source                           = "../../../../../modules/aws/ci-iam-role"
+  trusted_principal_arns           = concat(local.sso_infra_eng_role_arn_patterns, var.ci_trusted_principal_arns)
 }
 
 # Per-environment IAM Identity Center access for infrastructure engineers

--- a/terraform/env/development/aws/us-west-1/base-cluster-layer/outputs.tf
+++ b/terraform/env/development/aws/us-west-1/base-cluster-layer/outputs.tf
@@ -3,6 +3,11 @@ output "ci_iam_role_arn" {
   value       = module.ci_iam_role.role_arn
 }
 
+output "ci_read_only_iam_role_arn" {
+  description = "The ARN of the read-only IAM role assumed to plan and inspect Terraform-provisioned AWS resources"
+  value       = module.ci_iam_role.read_only_role_arn
+}
+
 output "eks_cluster_name" {
   description = "The name of the EKS cluster"
   value       = module.eks_cluster.eks_cluster_name

--- a/terraform/env/development/aws/us-west-1/base-cluster-layer/terraform.tfvars
+++ b/terraform/env/development/aws/us-west-1/base-cluster-layer/terraform.tfvars
@@ -1,6 +1,7 @@
-ami_type                   = "AL2023_x86_64_STANDARD"
-ci_trusted_principal_arns  = []
-enable_sso_infra_eng       = true
-environment_name           = "development"
-kubernetes_cluster_version = "1.29"
-project_tag                = "automation-calculator"
+ami_type                            = "AL2023_x86_64_STANDARD"
+ci_read_only_trusted_principal_arns = []
+ci_trusted_principal_arns           = []
+enable_sso_infra_eng                = true
+environment_name                    = "development"
+kubernetes_cluster_version          = "1.29"
+project_tag                         = "automation-calculator"

--- a/terraform/env/development/aws/us-west-1/base-cluster-layer/variables.tf
+++ b/terraform/env/development/aws/us-west-1/base-cluster-layer/variables.tf
@@ -10,6 +10,12 @@ variable "aws_region" {
   type        = string
 }
 
+variable "ci_read_only_trusted_principal_arns" {
+  default     = []
+  description = "IAM principal ARNs allowed to assume the read-only CI Terraform role. When empty, no principal can assume it."
+  type        = list(string)
+}
+
 variable "ci_trusted_principal_arns" {
   default     = []
   description = "IAM principal ARNs (CI users/roles) allowed to assume the CI Terraform role. When empty, no principal can assume it."

--- a/terraform/env/staging/aws/us-west-1/base-cluster-layer/main.tf
+++ b/terraform/env/staging/aws/us-west-1/base-cluster-layer/main.tf
@@ -7,17 +7,23 @@ locals {
   # on wildcard patterns. Safe to trust before the role exists, since the CI
   # role trust policy matches on aws:PrincipalArn rather than resolving the
   # principal.
-  sso_permission_set_name = "InfraEng${title(var.environment_name)}"
+  sso_permission_set_name           = "InfraEng${title(var.environment_name)}"
+  sso_permission_set_name_read_only = "InfraEng${title(var.environment_name)}ReadOnly"
   sso_infra_eng_role_arn_patterns = [
     "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_${local.sso_permission_set_name}_*",
     "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_${local.sso_permission_set_name}_*",
   ]
+  sso_infra_eng_read_only_role_arn_patterns = [
+    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_${local.sso_permission_set_name_read_only}_*",
+    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_${local.sso_permission_set_name_read_only}_*",
+  ]
 }
 
 module "ci_iam_role" {
-  environment_name       = var.environment_name
-  source                 = "../../../../../modules/aws/ci-iam-role"
-  trusted_principal_arns = concat(local.sso_infra_eng_role_arn_patterns, var.ci_trusted_principal_arns)
+  environment_name                 = var.environment_name
+  read_only_trusted_principal_arns = concat(local.sso_infra_eng_read_only_role_arn_patterns, var.ci_read_only_trusted_principal_arns)
+  source                           = "../../../../../modules/aws/ci-iam-role"
+  trusted_principal_arns           = concat(local.sso_infra_eng_role_arn_patterns, var.ci_trusted_principal_arns)
 }
 
 # Per-environment IAM Identity Center access for infrastructure engineers

--- a/terraform/env/staging/aws/us-west-1/base-cluster-layer/outputs.tf
+++ b/terraform/env/staging/aws/us-west-1/base-cluster-layer/outputs.tf
@@ -3,6 +3,11 @@ output "ci_iam_role_arn" {
   value       = module.ci_iam_role.role_arn
 }
 
+output "ci_read_only_iam_role_arn" {
+  description = "The ARN of the read-only IAM role assumed to plan and inspect Terraform-provisioned AWS resources"
+  value       = module.ci_iam_role.read_only_role_arn
+}
+
 output "eks_cluster_name" {
   description = "The name of the EKS cluster"
   value       = module.eks_cluster.eks_cluster_name

--- a/terraform/env/staging/aws/us-west-1/base-cluster-layer/terraform.tfvars
+++ b/terraform/env/staging/aws/us-west-1/base-cluster-layer/terraform.tfvars
@@ -1,6 +1,7 @@
-ami_type                   = "AL2023_x86_64_STANDARD"
-ci_trusted_principal_arns  = []
-enable_sso_infra_eng       = true
-environment_name           = "staging"
-kubernetes_cluster_version = "1.35"
-project_tag                = "automation-calculator"
+ami_type                            = "AL2023_x86_64_STANDARD"
+ci_read_only_trusted_principal_arns = []
+ci_trusted_principal_arns           = []
+enable_sso_infra_eng                = true
+environment_name                    = "staging"
+kubernetes_cluster_version          = "1.35"
+project_tag                         = "automation-calculator"

--- a/terraform/env/staging/aws/us-west-1/base-cluster-layer/variables.tf
+++ b/terraform/env/staging/aws/us-west-1/base-cluster-layer/variables.tf
@@ -10,6 +10,12 @@ variable "aws_region" {
   type        = string
 }
 
+variable "ci_read_only_trusted_principal_arns" {
+  default     = []
+  description = "IAM principal ARNs allowed to assume the read-only CI Terraform role. When empty, no principal can assume it."
+  type        = list(string)
+}
+
 variable "ci_trusted_principal_arns" {
   default     = []
   description = "IAM principal ARNs (CI users/roles) allowed to assume the CI Terraform role. When empty, no principal can assume it."

--- a/terraform/modules/aws/ci-iam-role/main.tf
+++ b/terraform/modules/aws/ci-iam-role/main.tf
@@ -4,14 +4,25 @@ locals {
   role_name   = "ac_ci_terraform_${var.environment_name}"
   policy_name = "ac_ci_terraform_${var.environment_name}"
 
+  read_only_role_name   = "ac_ci_terraform_${var.environment_name}_read_only"
+  read_only_policy_name = "ac_ci_terraform_${var.environment_name}_read_only"
+
   # When no principals are listed, fall back to a sentinel in a different
-  # (nonexistent) account. The trust statement below is already scoped to this
-  # account's principals, so the sentinel can never match and the role is
+  # (nonexistent) account. The trust statements below are already scoped to
+  # this account's principals, so the sentinel can never match and the role is
   # assumable by no one until ARNs are explicitly added.
+  no_principals_sentinel = ["arn:aws:iam::000000000000:root"]
+
   trusted_principal_arns = (
     length(var.trusted_principal_arns) > 0
     ? var.trusted_principal_arns
-    : ["arn:aws:iam::000000000000:root"]
+    : local.no_principals_sentinel
+  )
+
+  read_only_trusted_principal_arns = (
+    length(var.read_only_trusted_principal_arns) > 0
+    ? var.read_only_trusted_principal_arns
+    : local.no_principals_sentinel
   )
 }
 
@@ -41,10 +52,40 @@ data "aws_iam_policy_document" "assume_role" {
   }
 }
 
+# Same trust shape as the read-write role above, gated on its own allowlist.
+data "aws_iam_policy_document" "assume_role_read_only" {
+  statement {
+    sid     = "AllowReadOnlyPrincipalsToAssume"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+
+    condition {
+      test     = "ArnLike"
+      variable = "aws:PrincipalArn"
+      values   = local.read_only_trusted_principal_arns
+    }
+  }
+}
+
 resource "aws_iam_role" "ci" {
   name                 = local.role_name
   description          = "Assumed by CI to run Terraform plans and applies for the ${var.environment_name} environment"
   assume_role_policy   = data.aws_iam_policy_document.assume_role.json
+  max_session_duration = var.max_session_duration
+
+  tags = {
+    Project = "automation_calculator"
+  }
+}
+
+resource "aws_iam_role" "ci_read_only" {
+  name                 = local.read_only_role_name
+  description          = "Assumed to run read-only Terraform plans and inspect resources for the ${var.environment_name} environment"
+  assume_role_policy   = data.aws_iam_policy_document.assume_role_read_only.json
   max_session_duration = var.max_session_duration
 
   tags = {
@@ -82,6 +123,62 @@ data "aws_iam_policy_document" "ci_permissions" {
   }
 }
 
+# Read-only counterpart of ci_permissions: the same services, restricted to
+# the Describe/Get/List action verbs uniformly. IAM ignores verb patterns a
+# service doesn't define, so the uniform shape is harmless and keeps the two
+# statements easy to diff against the read-write list. Enough for terraform
+# plan and for inspecting resources; no mutation verbs.
+data "aws_iam_policy_document" "ci_read_only_permissions" {
+  statement {
+    sid = "ReadInfrastructureServices"
+    actions = [
+      "acm:Describe*",
+      "acm:Get*",
+      "acm:List*",
+      "autoscaling:Describe*",
+      "autoscaling:Get*",
+      "autoscaling:List*",
+      "cloudwatch:Describe*",
+      "cloudwatch:Get*",
+      "cloudwatch:List*",
+      "ec2:Describe*",
+      "ec2:Get*",
+      "ec2:List*",
+      "eks:Describe*",
+      "eks:Get*",
+      "eks:List*",
+      "elasticloadbalancing:Describe*",
+      "elasticloadbalancing:Get*",
+      "elasticloadbalancing:List*",
+      "kms:Describe*",
+      "kms:Get*",
+      "kms:List*",
+      "logs:Describe*",
+      "logs:Get*",
+      "logs:List*",
+      "rds:Describe*",
+      "rds:Get*",
+      "rds:List*",
+      "route53:Get*",
+      "route53:List*",
+      "route53domains:Get*",
+      "route53domains:List*",
+      "sns:Get*",
+      "sns:List*",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "ReadIamForTerraformPlan"
+    actions = [
+      "iam:Get*",
+      "iam:List*",
+    ]
+    resources = ["*"]
+  }
+}
+
 resource "aws_iam_policy" "ci" {
   name        = local.policy_name
   description = "Permissions for CI to manage Terraform-provisioned AWS resources in ${var.environment_name}"
@@ -92,7 +189,22 @@ resource "aws_iam_policy" "ci" {
   }
 }
 
+resource "aws_iam_policy" "ci_read_only" {
+  name        = local.read_only_policy_name
+  description = "Read-only permissions to plan and inspect Terraform-provisioned AWS resources in ${var.environment_name}"
+  policy      = data.aws_iam_policy_document.ci_read_only_permissions.json
+
+  tags = {
+    Project = "automation_calculator"
+  }
+}
+
 resource "aws_iam_role_policy_attachment" "ci" {
   role       = aws_iam_role.ci.name
   policy_arn = aws_iam_policy.ci.arn
+}
+
+resource "aws_iam_role_policy_attachment" "ci_read_only" {
+  role       = aws_iam_role.ci_read_only.name
+  policy_arn = aws_iam_policy.ci_read_only.arn
 }

--- a/terraform/modules/aws/ci-iam-role/outputs.tf
+++ b/terraform/modules/aws/ci-iam-role/outputs.tf
@@ -12,3 +12,18 @@ output "policy_arn" {
   description = "The ARN of the IAM policy attached to the CI role."
   value       = aws_iam_policy.ci.arn
 }
+
+output "read_only_role_arn" {
+  description = "The ARN of the read-only CI IAM role."
+  value       = aws_iam_role.ci_read_only.arn
+}
+
+output "read_only_role_name" {
+  description = "The name of the read-only CI IAM role."
+  value       = aws_iam_role.ci_read_only.name
+}
+
+output "read_only_policy_arn" {
+  description = "The ARN of the IAM policy attached to the read-only CI role."
+  value       = aws_iam_policy.ci_read_only.arn
+}

--- a/terraform/modules/aws/ci-iam-role/variables.tf
+++ b/terraform/modules/aws/ci-iam-role/variables.tf
@@ -9,6 +9,12 @@ variable "max_session_duration" {
   type        = number
 }
 
+variable "read_only_trusted_principal_arns" {
+  default     = []
+  description = "IAM principal ARNs in this account allowed to assume the read-only CI role. When empty (the default), no principal can assume the role."
+  type        = list(string)
+}
+
 variable "trusted_principal_arns" {
   default     = []
   description = "IAM principal ARNs (CI users/roles) in this account allowed to assume the CI role. When empty (the default), no principal can assume the role."

--- a/terraform/modules/aws/sso-infra-eng/main.tf
+++ b/terraform/modules/aws/sso-infra-eng/main.tf
@@ -16,6 +16,12 @@ locals {
     ? var.permission_set_name
     : "InfraEng${title(var.environment_name)}"
   )
+
+  read_only_permission_set_name = (
+    var.read_only_permission_set_name != ""
+    ? var.read_only_permission_set_name
+    : "InfraEng${title(var.environment_name)}ReadOnly"
+  )
 }
 
 resource "aws_ssoadmin_permission_set" "infra_eng" {
@@ -43,6 +49,34 @@ resource "aws_ssoadmin_permission_set_inline_policy" "infra_eng" {
   permission_set_arn = aws_ssoadmin_permission_set.infra_eng.arn
 }
 
+# Read-only variant: same shape as InfraEng<Env>, but its inline policy only
+# allows assuming the read-only CI role, for plans and inspection without
+# write access.
+resource "aws_ssoadmin_permission_set" "infra_eng_read_only" {
+  name             = local.read_only_permission_set_name
+  description      = "Infrastructure engineers (read-only): assume the ${var.environment_name} read-only CI Terraform role"
+  instance_arn     = local.instance_arn
+  session_duration = var.session_duration
+
+  tags = {
+    Project = "automation_calculator"
+  }
+}
+
+data "aws_iam_policy_document" "infra_eng_read_only" {
+  statement {
+    sid       = "AssumeCiTerraformReadOnlyRole"
+    actions   = ["sts:AssumeRole"]
+    resources = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/ac_ci_terraform_${var.environment_name}_read_only"]
+  }
+}
+
+resource "aws_ssoadmin_permission_set_inline_policy" "infra_eng_read_only" {
+  inline_policy      = data.aws_iam_policy_document.infra_eng_read_only.json
+  instance_arn       = local.instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.infra_eng_read_only.arn
+}
+
 # The Identity Center user is provisioned from the external identity provider
 # (Google Workspace SCIM auto-provisioning, or created manually with the same
 # userName), not by Terraform. Looked up here so the account assignment fails
@@ -63,6 +97,18 @@ resource "aws_ssoadmin_account_assignment" "infra_eng" {
   count              = var.user_name == "" ? 0 : 1
   instance_arn       = local.instance_arn
   permission_set_arn = aws_ssoadmin_permission_set.infra_eng.arn
+  principal_id       = data.aws_identitystore_user.infra_eng[0].user_id
+  principal_type     = "USER"
+  target_id          = data.aws_caller_identity.current.account_id
+  target_type        = "AWS_ACCOUNT"
+}
+
+# The same engineer gets both permission sets and picks the read-only or
+# read-write persona at sign-in.
+resource "aws_ssoadmin_account_assignment" "infra_eng_read_only" {
+  count              = var.user_name == "" ? 0 : 1
+  instance_arn       = local.instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.infra_eng_read_only.arn
   principal_id       = data.aws_identitystore_user.infra_eng[0].user_id
   principal_type     = "USER"
   target_id          = data.aws_caller_identity.current.account_id

--- a/terraform/modules/aws/sso-infra-eng/outputs.tf
+++ b/terraform/modules/aws/sso-infra-eng/outputs.tf
@@ -7,3 +7,13 @@ output "permission_set_name" {
   description = "The name of the InfraEng permission set."
   value       = aws_ssoadmin_permission_set.infra_eng.name
 }
+
+output "read_only_permission_set_arn" {
+  description = "The ARN of the read-only InfraEng permission set."
+  value       = aws_ssoadmin_permission_set.infra_eng_read_only.arn
+}
+
+output "read_only_permission_set_name" {
+  description = "The name of the read-only InfraEng permission set."
+  value       = aws_ssoadmin_permission_set.infra_eng_read_only.name
+}

--- a/terraform/modules/aws/sso-infra-eng/variables.tf
+++ b/terraform/modules/aws/sso-infra-eng/variables.tf
@@ -9,6 +9,12 @@ variable "permission_set_name" {
   type        = string
 }
 
+variable "read_only_permission_set_name" {
+  default     = ""
+  description = "Name of the read-only IAM Identity Center permission set. Defaults to InfraEng<EnvironmentName>ReadOnly. Also determines the AWSReservedSSO_<name>_* role name that the read-only CI role trust policy matches on."
+  type        = string
+}
+
 variable "session_duration" {
   default     = "PT8H"
   description = "ISO-8601 session duration for the permission set."


### PR DESCRIPTION
## Summary

Refactors the per-environment access pattern into a read/write pair so engineers (and eventually CI plan jobs) can operate without write access:

- **`ci-iam-role` module** — alongside the existing `ac_ci_terraform_<env>` role, provisions `ac_ci_terraform_<env>_read_only`. Its policy mirrors the read-write service list but restricted uniformly to `Describe*`/`Get*`/`List*` verbs (plus `iam:Get*`/`iam:List*`) — enough for `terraform plan` and resource inspection, no mutation. Trust is gated on a separate `read_only_trusted_principal_arns` allowlist with the same nobody-can-assume sentinel fallback when empty.
- **`sso-infra-eng` module** — adds an `InfraEng<Env>ReadOnly` Identity Center permission set whose inline policy may only assume the read-only role. The same engineer is assigned both permission sets and picks the read-only or read-write persona at sign-in.
- **dev + staging env configs** — trust the `AWSReservedSSO_InfraEng<Env>ReadOnly_*` role patterns on the read-only role, add the `ci_read_only_trusted_principal_arns` variable/tfvars entry, and output `ci_read_only_iam_role_arn`.

Production is untouched (it does not yet instantiate these modules, matching #296/#299 scope).

No changes to existing resource addresses or names — the read-write role, policy, and permission set are byte-identical, so applying should only add resources.

## Validation

- `terraform fmt -check -recursive terraform/` passes
- `terraform validate` passes in both modules and both env configs (dev + staging base-cluster-layer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)