### PR TITLE
Grant read-only CI Terraform role EKS view access (dev + staging)

### DIFF
--- a/terraform/env/development/aws/us-west-1/base-cluster-layer/main.tf
+++ b/terraform/env/development/aws/us-west-1/base-cluster-layer/main.tf
@@ -49,15 +49,26 @@ module "eks_cluster" {
   vpc_id           = module.networking_layer.vpc.id
   ami_type         = var.ami_type
 
-  # Grants the CI Terraform role kubectl/Helm access to the cluster API.
-  # Human InfraEng access flows through the same role: SSO users assume it
-  # (see ci_iam_role trust policy), so no per-user entries are needed.
+  # Grants the CI Terraform roles kubectl/Helm access to the cluster API.
+  # Human InfraEng access flows through the same roles: SSO users assume
+  # them (see ci_iam_role trust policies), so no per-user entries are
+  # needed. The read-only role gets the view policy, matching its
+  # plan-and-inspect-only IAM permissions.
   access_entries = {
     ci_terraform = {
       principal_arn = module.ci_iam_role.role_arn
       policy_associations = {
         cluster_admin = {
           policy_arn   = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+          access_scope = { type = "cluster" }
+        }
+      }
+    }
+    ci_terraform_read_only = {
+      principal_arn = module.ci_iam_role.read_only_role_arn
+      policy_associations = {
+        view = {
+          policy_arn   = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSViewPolicy"
           access_scope = { type = "cluster" }
         }
       }

--- a/terraform/env/staging/aws/us-west-1/base-cluster-layer/main.tf
+++ b/terraform/env/staging/aws/us-west-1/base-cluster-layer/main.tf
@@ -54,15 +54,26 @@ module "eks_cluster" {
     min_size     = 1
   }
 
-  # Grants the CI Terraform role kubectl/Helm access to the cluster API.
-  # Human InfraEng access flows through the same role: SSO users assume it
-  # (see ci_iam_role trust policy), so no per-user entries are needed.
+  # Grants the CI Terraform roles kubectl/Helm access to the cluster API.
+  # Human InfraEng access flows through the same roles: SSO users assume
+  # them (see ci_iam_role trust policies), so no per-user entries are
+  # needed. The read-only role gets the view policy, matching its
+  # plan-and-inspect-only IAM permissions.
   access_entries = {
     ci_terraform = {
       principal_arn = module.ci_iam_role.role_arn
       policy_associations = {
         cluster_admin = {
           policy_arn   = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+          access_scope = { type = "cluster" }
+        }
+      }
+    }
+    ci_terraform_read_only = {
+      principal_arn = module.ci_iam_role.read_only_role_arn
+      policy_associations = {
+        view = {
+          policy_arn   = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSViewPolicy"
           access_scope = { type = "cluster" }
         }
       }


### PR DESCRIPTION
## Summary

Follow-up to #301 and #302. The `ac_ci_terraform_<env>_read_only` roles can generate a kubeconfig (`eks:DescribeCluster`), but kubectl calls return Unauthorized because the clusters have no access entry for them — verified against `ac_app_staging` after #302 applied.

Adds a second entry to the existing `access_entries` block in the dev and staging env configs:

- `ci_terraform_read_only` → `module.ci_iam_role.read_only_role_arn` with **`AmazonEKSViewPolicy`**, cluster-scoped — read-only Kubernetes API access (get/list/watch on most resources, no secrets values), matching the role's plan-and-inspect-only IAM permissions.

The existing read-write `ci_terraform` entry (AmazonEKSClusterAdminPolicy, #301) is unchanged. Production stays unwired since the CI role module is not provisioned there yet.

## Validation

- `terraform fmt -check -recursive terraform/` passes
- `terraform validate` passes in both env configs (dev + staging base-cluster-layer)
- After the staging workspace applies, `kubectl get nodes` under the `ac-ci-staging-ro` profile chain should succeed where it previously returned Unauthorized

🤖 Generated with [Claude Code](https://claude.com/claude-code)