### PR TITLE
Roll out CI Terraform role and InfraEng SSO access to production

### DIFF
--- a/terraform/env/production/aws/us-west-1/base-cluster-layer/main.tf
+++ b/terraform/env/production/aws/us-west-1/base-cluster-layer/main.tf
@@ -1,3 +1,46 @@
+data "aws_caller_identity" "current" {}
+
+locals {
+  # IAM role that Identity Center provisions for this environment's InfraEng
+  # permission set. Its name carries a random suffix (and, depending on the
+  # Identity Center instance region, a region path segment), so trust matches
+  # on wildcard patterns. Safe to trust before the role exists, since the CI
+  # role trust policy matches on aws:PrincipalArn rather than resolving the
+  # principal.
+  sso_permission_set_name           = "InfraEng${title(var.environment_name)}"
+  sso_permission_set_name_read_only = "InfraEng${title(var.environment_name)}ReadOnly"
+  sso_infra_eng_role_arn_patterns = [
+    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_${local.sso_permission_set_name}_*",
+    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_${local.sso_permission_set_name}_*",
+  ]
+  sso_infra_eng_read_only_role_arn_patterns = [
+    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_${local.sso_permission_set_name_read_only}_*",
+    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_${local.sso_permission_set_name_read_only}_*",
+  ]
+}
+
+module "ci_iam_role" {
+  environment_name                 = var.environment_name
+  read_only_trusted_principal_arns = concat(local.sso_infra_eng_read_only_role_arn_patterns, var.ci_read_only_trusted_principal_arns)
+  source                           = "../../../../../modules/aws/ci-iam-role"
+  trusted_principal_arns           = concat(local.sso_infra_eng_role_arn_patterns, var.ci_trusted_principal_arns)
+}
+
+# Per-environment IAM Identity Center access for infrastructure engineers
+# (Google Workspace federated): each environment's workspace creates its own
+# InfraEng<Env> permission set scoped to that environment's CI role. Runs
+# against us-east-1, where the Identity Center organization instance lives.
+# Gated off until the Google Workspace identity provider is connected and
+# the user is provisioned — manual console steps.
+module "sso_infra_eng" {
+  count            = var.enable_sso_infra_eng ? 1 : 0
+  environment_name = var.environment_name
+  source           = "../../../../../modules/aws/sso-infra-eng"
+  providers = {
+    aws = aws.us_east_1
+  }
+}
+
 module "eks_cluster" {
   environment_name = var.environment_name
   cluster_version  = var.kubernetes_cluster_version
@@ -9,6 +52,21 @@ module "eks_cluster" {
     desired_size = 1
     max_size     = 2
     min_size     = 1
+  }
+
+  # Grants the CI Terraform role kubectl/Helm access to the cluster API.
+  # Human InfraEng access flows through the same role: SSO users assume it
+  # (see ci_iam_role trust policy), so no per-user entries are needed.
+  access_entries = {
+    ci_terraform = {
+      principal_arn = module.ci_iam_role.role_arn
+      policy_associations = {
+        cluster_admin = {
+          policy_arn   = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+          access_scope = { type = "cluster" }
+        }
+      }
+    }
   }
 }
 

--- a/terraform/env/production/aws/us-west-1/base-cluster-layer/outputs.tf
+++ b/terraform/env/production/aws/us-west-1/base-cluster-layer/outputs.tf
@@ -1,3 +1,13 @@
+output "ci_iam_role_arn" {
+  description = "The ARN of the IAM role CI assumes to manage Terraform-provisioned AWS resources"
+  value       = module.ci_iam_role.role_arn
+}
+
+output "ci_read_only_iam_role_arn" {
+  description = "The ARN of the read-only IAM role assumed to plan and inspect Terraform-provisioned AWS resources"
+  value       = module.ci_iam_role.read_only_role_arn
+}
+
 output "eks_cluster_name" {
   description = "The name of the EKS cluster"
   value       = module.eks_cluster.eks_cluster_name

--- a/terraform/env/production/aws/us-west-1/base-cluster-layer/provider.tf
+++ b/terraform/env/production/aws/us-west-1/base-cluster-layer/provider.tf
@@ -8,3 +8,17 @@ provider "aws" {
     }
   }
 }
+
+# The IAM Identity Center organization instance lives in us-east-1 (its
+# primary region); ssoadmin/identitystore API calls must target that region.
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+  default_tags {
+    tags = {
+      Environment = var.environment_name,
+      Project     = var.project_tag,
+      SourceRepo  = "https://github.com/team-automation-calculator/core-iac"
+    }
+  }
+}

--- a/terraform/env/production/aws/us-west-1/base-cluster-layer/terraform.tfvars
+++ b/terraform/env/production/aws/us-west-1/base-cluster-layer/terraform.tfvars
@@ -1,4 +1,7 @@
-ami_type                   = "AL2023_x86_64_STANDARD"
-environment_name           = "production"
-kubernetes_cluster_version = "1.35"
-project_tag                = "automation-calculator"
+ami_type                            = "AL2023_x86_64_STANDARD"
+ci_read_only_trusted_principal_arns = []
+ci_trusted_principal_arns           = []
+enable_sso_infra_eng                = true
+environment_name                    = "production"
+kubernetes_cluster_version          = "1.35"
+project_tag                         = "automation-calculator"

--- a/terraform/env/production/aws/us-west-1/base-cluster-layer/variables.tf
+++ b/terraform/env/production/aws/us-west-1/base-cluster-layer/variables.tf
@@ -10,6 +10,24 @@ variable "aws_region" {
   type        = string
 }
 
+variable "ci_read_only_trusted_principal_arns" {
+  default     = []
+  description = "IAM principal ARNs allowed to assume the read-only CI Terraform role. When empty, no principal can assume it."
+  type        = list(string)
+}
+
+variable "ci_trusted_principal_arns" {
+  default     = []
+  description = "IAM principal ARNs (CI users/roles) allowed to assume the CI Terraform role. When empty, no principal can assume it."
+  type        = list(string)
+}
+
+variable "enable_sso_infra_eng" {
+  default     = false
+  description = "Create the IAM Identity Center InfraEng permission set and account assignment for this environment. Enable only after the Identity Center instance exists and the Google Workspace identity provider is connected."
+  type        = bool
+}
+
 variable "environment_name" {
   description = "The application production environment, i.e development/staging/production."
   type        = string


### PR DESCRIPTION
## Summary

Ports the CI/InfraEng IAM configuration already live in dev and staging (#296, #297, #299, #301, #302) to the production `base-cluster-layer`. Production now matches staging exactly except for the environment name and TFE workspace.

- **`ci_iam_role` module** — creates `ac_ci_terraform_production` and `ac_ci_terraform_production_read_only`, with trust policies matching the `InfraEngProduction` / `InfraEngProductionReadOnly` SSO role ARN patterns (plus the empty `ci_*_trusted_principal_arns` allowlists for future CI principals).
- **`sso_infra_eng` module** (`enable_sso_infra_eng = true`) — creates the `InfraEngProduction` and `InfraEngProductionReadOnly` permission sets and account assignments via the us-east-1 aliased provider (Identity Center org instance region). Google Workspace IdP is already connected, so no manual gating steps remain.
- **EKS access entry** — grants the read-write CI role `AmazonEKSClusterAdminPolicy` on the `ac_app_production` cluster (same as #301 did for dev/staging).
- New outputs: `ci_iam_role_arn`, `ci_read_only_iam_role_arn`.

## Verification

- `terraform fmt -check -recursive terraform/` — clean
- `terraform init -backend=false && terraform validate` in `terraform/env/production/aws/us-west-1/base-cluster-layer` — valid
- Directory diff vs staging shows only `environment_name` and TFE workspace name differ

## Apply / follow-up

- Apply via the `ac_app_base_cluster_layer_production` TFE workspace; the speculative plan on this PR should show only additions.
- After apply, verify the chain: SSO portal → `InfraEngProduction` → assume `ac_ci_terraform_production` → `kubectl get nodes` against `ac_app_production` (add `infra-eng-production` / `ac-ci-production` profiles to `~/.aws/config` mirroring the staging ones).
- Note: as in staging, the read-only role gets no EKS access entry here — #303 adds `AmazonEKSViewPolicy` entries for the `_read_only` roles and can extend to prod once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)