### PR TITLE
Make aws configure sso the exclusive human AWS auth method

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,11 @@ Body"
 ```
 TFE_TOKEN                  # Terraform Cloud API token
 TF_VAR_GITHUB_TOKEN        # GitHub token (passed as TF variable)
-AWS_ACCESS_KEY_ID
-AWS_SECRET_ACCESS_KEY
+AWS_PROFILE                # SSO-chained CI role profile, e.g. ac-ci-staging (see docs/aws-sso-auth.md)
 ```
+
+## AWS Authentication
+
+Human AWS access is **IAM Identity Center (SSO) only — no IAM user access keys**. Never set `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` locally and never create IAM users or access keys for human access. Authenticate with `aws sso login` and select a role with `AWS_PROFILE` (profiles chain SSO → `ac_ci_terraform_<env>`). Setup and profile reference: `docs/aws-sso-auth.md`.
+
+Terraform Cloud remote runs are the one exception: workspace variables in TFC hold CI credentials; they are managed in TFC, never locally.

--- a/README.md
+++ b/README.md
@@ -12,3 +12,8 @@ Infrastructure as Code for all apps within this project, including the main one.
 6. Apply base layer from its workspace
 7. Apply cluster addons layer from its workspace
 8. Profit?
+
+# AWS CLI Access
+
+Human AWS access is IAM Identity Center (SSO) only — no IAM user access keys.
+See [docs/aws-sso-auth.md](docs/aws-sso-auth.md) for setup and the profile reference.

--- a/docs/aws-sso-auth.md
+++ b/docs/aws-sso-auth.md
@@ -1,0 +1,113 @@
+# AWS Authentication: IAM Identity Center (SSO) Only
+
+Human AWS access to this project uses **IAM Identity Center (SSO) exclusively**.
+IAM users and long-lived access keys are not used for human access — do not
+create them, and never set `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` in your
+shell or `~/.aws/credentials`.
+
+Every credential in the human path is a short-lived STS token:
+
+```
+Google Workspace login
+  → IAM Identity Center (SSO)                     aws sso login
+    → InfraEng<Env>[ReadOnly] permission set      sso_role_name
+      → ac_ci_terraform_<env>[_read_only] role    chained via role_arn/source_profile
+```
+
+The `InfraEng<Env>` permission sets and the trust policies that let them assume
+the CI roles are managed in Terraform (`terraform/modules/aws/sso-infra-eng`
+and `terraform/modules/aws/ci-iam-role`, wired per environment in
+`terraform/env/<env>/aws/us-west-1/base-cluster-layer`).
+
+## One-time setup
+
+Requires AWS CLI v2. Either run the wizard:
+
+```bash
+aws configure sso   # start URL: your Identity Center portal URL; SSO region: us-east-1
+```
+
+or paste the config below into `~/.aws/config`, filling in the account ID and
+start URL (find them in the Identity Center console or ask an existing infra
+engineer — this repo is public, so they are not committed here):
+
+```ini
+# One SSO session shared by all profiles: a single login covers everything.
+[sso-session ac]
+sso_start_url = https://<IDENTITY_CENTER_PORTAL>.awsapps.com/start
+sso_region = us-east-1
+sso_registration_scopes = sso:account:access
+
+# SSO login profiles — one per environment's InfraEng permission set.
+[profile infra-eng-dev]
+sso_session = ac
+sso_account_id = <ACCOUNT_ID>
+sso_role_name = InfraEngDevelopment
+region = us-west-1
+
+[profile infra-eng-staging]
+sso_session = ac
+sso_account_id = <ACCOUNT_ID>
+sso_role_name = InfraEngStaging
+region = us-west-1
+
+[profile infra-eng-production]
+sso_session = ac
+sso_account_id = <ACCOUNT_ID>
+sso_role_name = InfraEngProduction
+region = us-west-1
+
+# Read-only personas: plans, inspection, kubeconfig updates — no writes.
+[profile infra-eng-staging-ro]
+sso_session = ac
+sso_account_id = <ACCOUNT_ID>
+sso_role_name = InfraEngStagingReadOnly
+region = us-west-1
+
+# Chained CI role profiles — what Terraform/AWS CLI work should run as.
+# Each assumes the environment's CI role using the SSO profile's credentials.
+[profile ac-ci-dev]
+role_arn = arn:aws:iam::<ACCOUNT_ID>:role/ac_ci_terraform_development
+source_profile = infra-eng-dev
+region = us-west-1
+
+[profile ac-ci-staging]
+role_arn = arn:aws:iam::<ACCOUNT_ID>:role/ac_ci_terraform_staging
+source_profile = infra-eng-staging
+region = us-west-1
+
+[profile ac-ci-production]
+role_arn = arn:aws:iam::<ACCOUNT_ID>:role/ac_ci_terraform_production
+source_profile = infra-eng-production
+region = us-west-1
+
+[profile ac-ci-staging-ro]
+role_arn = arn:aws:iam::<ACCOUNT_ID>:role/ac_ci_terraform_staging_read_only
+source_profile = infra-eng-staging-ro
+region = us-west-1
+```
+
+Add `-ro` profile pairs for other environments as their read-only permission
+sets are provisioned, following the staging pattern above.
+
+## Daily use
+
+```bash
+aws sso login --profile infra-eng-staging   # one browser login covers all profiles
+
+AWS_PROFILE=ac-ci-staging aws sts get-caller-identity   # verify the chain
+AWS_PROFILE=ac-ci-staging terraform plan                # terraform against an env
+AWS_PROFILE=ac-ci-staging scripts/update_kubeconfigs.sh # refresh kubeconfigs
+AWS_PROFILE=ac-ci-staging kubectl get nodes             # kubectl (read-write role only)
+```
+
+Prefer the `-ro` profiles for anything that only reads (plans, inspection,
+`update_kubeconfigs.sh`).
+
+## What is NOT used
+
+- **IAM users / access keys for humans** — none. If you find a human-use IAM
+  user or an active access key for one, deactivate and delete it.
+- **`~/.aws/credentials`** — should not exist, or should be empty.
+- The one legitimate access-key holder is Terraform Cloud: its remote runs
+  authenticate via workspace variables managed in TFC, never locally.


### PR DESCRIPTION
## Summary

Establishes SSO (`aws configure sso` / `aws sso login`) as the **only** human AWS auth path and eliminates IAM-user access keys from the workflow. The repo itself never managed access keys in Terraform, so this PR removes the last places the access-key path lived in-repo and documents the policy:

- **CLAUDE.md** — drops `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` from Required Environment Variables (replaced by `AWS_PROFILE`), and adds an *AWS Authentication* section: SSO only, never set static keys locally, never create IAM users/keys for human access.
- **docs/aws-sso-auth.md** (new) — the full auth chain (Google Workspace → Identity Center → `InfraEng<Env>[ReadOnly]` permission set → `ac_ci_terraform_<env>[_read_only]`), one-time `aws configure sso` setup, a complete `~/.aws/config` profile reference (dev/staging/production + read-only personas), and daily-use commands. Account ID and portal URL are placeholders since this repo is public.
- **README.md** — points at the new doc.

## Relationship to other PRs

- **Supersedes #298** (`suray` IAM user + `ac_infra_eng` role, the non-SSO fallback that required an out-of-band bootstrap access key). With SSO verified working end-to-end, that path is no longer wanted — #298 can be closed without merging.
- The `infra-eng-production` / `ac-ci-production` profiles documented here become usable once #304 (prod CI + InfraEng rollout) is applied.

## Follow-up (console/CLI, not in this PR)

- Deactivate and delete any existing human-use IAM access keys in the account (e.g. keys on the bootstrap `automation-calculator` user that were used for CLI access). Terraform Cloud's workspace-variable credentials are the one legitimate key holder and stay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)