### PR TITLE
Reject Identity Center instance URLs in infra_eng_sso.py

### DIFF
--- a/docs/aws-sso-auth.md
+++ b/docs/aws-sso-auth.md
@@ -29,12 +29,15 @@ aws configure sso   # start URL: your Identity Center portal URL; SSO region: us
 
 or paste the config below into `~/.aws/config`, filling in the account ID and
 start URL (find them in the Identity Center console or ask an existing infra
-engineer — this repo is public, so they are not committed here):
+engineer — this repo is public, so they are not committed here). The start URL
+is the **AWS access portal URL**, which comes in two forms depending on the
+instance: `https://<subdomain>.awsapps.com/start` or the newer
+`https://ssoins-<id>.portal.<region>.app.aws`.
 
 ```ini
 # One SSO session shared by all profiles: a single login covers everything.
 [sso-session ac]
-sso_start_url = https://<IDENTITY_CENTER_PORTAL>.awsapps.com/start
+sso_start_url = <AWS_ACCESS_PORTAL_URL>
 sso_region = us-east-1
 sso_registration_scopes = sso:account:access
 
@@ -118,8 +121,9 @@ browser, or Google federating the wrong account. In order:
 2. If a normal window is needed, clear cookies for `awsapps.com`,
    `signin.aws.amazon.com`, and `aws.amazon.com`, then retry.
 3. Only if it persists in a private window, re-check the config: `sso_start_url`
-   must be the access portal URL (`https://<subdomain>.awsapps.com/start`) and
-   `sso_region` must be the Identity Center home region (`us-east-1`).
+   must be the access portal URL (`https://<subdomain>.awsapps.com/start` or
+   `https://ssoins-<id>.portal.<region>.app.aws`) and `sso_region` must be the
+   Identity Center home region (`us-east-1`).
 
 ## What is NOT used
 

--- a/docs/aws-sso-auth.md
+++ b/docs/aws-sso-auth.md
@@ -104,6 +104,23 @@ AWS_PROFILE=ac-ci-staging kubectl get nodes             # kubectl (read-write ro
 Prefer the `-ro` profiles for anything that only reads (plans, inspection,
 `update_kubeconfigs.sh`).
 
+## Troubleshooting
+
+**Browser shows "Something doesn't compute — We couldn't verify your sign-in
+credentials" during `aws sso login`.** The local config is usually not the
+problem: `aws sso login` builds the authorization URL from a client it
+registers fresh, and this error page comes from the AWS sign-in service later
+in the browser flow — stale Identity Center / AWS sign-in session state in the
+browser, or Google federating the wrong account. In order:
+
+1. Retry in a private/incognito window and pick your **Workspace** account in
+   the Google sign-in (not a personal Google account).
+2. If a normal window is needed, clear cookies for `awsapps.com`,
+   `signin.aws.amazon.com`, and `aws.amazon.com`, then retry.
+3. Only if it persists in a private window, re-check the config: `sso_start_url`
+   must be the access portal URL (`https://<subdomain>.awsapps.com/start`) and
+   `sso_region` must be the Identity Center home region (`us-east-1`).
+
 ## What is NOT used
 
 - **IAM users / access keys for humans** — none. If you find a human-use IAM

--- a/scripts/infra_eng_sso.py
+++ b/scripts/infra_eng_sso.py
@@ -13,14 +13,16 @@ Manages the InfraEng SSO flow end to end for one environment:
 3. Updates the kubeconfig for the environment's EKS clusters with the
    chained profile embedded, so kubectl works without any shell setup.
 
-A child process cannot set AWS_PROFILE in the calling shell, so to point
-subsequent commands at the chained profile either eval the export line:
+A child process cannot set AWS_PROFILE in the calling shell, so `up` and
+`login` print an eval-able export line for the chained profile as their
+only stdout (all progress output goes to stderr). To log in and point the
+current shell at the profile in one step:
+
+    eval "$(scripts/infra_eng_sso.py up --environment staging)"
+
+Without eval, copy the printed export line, or print it again any time with:
 
     eval "$(scripts/infra_eng_sso.py export --environment staging)"
-
-or run the full flow and copy the printed export line:
-
-    scripts/infra_eng_sso.py up --environment staging
 
 First run needs --sso-start-url and --account-id; both are persisted in
 ~/.aws/config and read back on later runs. The start URL must be the AWS
@@ -197,17 +199,16 @@ def configure(environment: str, read_only: bool, sso_start_url: str | None, acco
 
     AWS_CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
     AWS_CONFIG_PATH.write_text(config_text)
-    print(f"configured profiles {sso_profile} -> {ci_profile} in {AWS_CONFIG_PATH}")
+    print(f"configured profiles {sso_profile} -> {ci_profile} in {AWS_CONFIG_PATH}", file=sys.stderr)
     return ci_profile
 
 
 def aws(*args: str, capture: bool = False) -> subprocess.CompletedProcess:
-    return subprocess.run(
-        ["aws", *args],
-        check=True,
-        capture_output=capture,
-        text=True,
-    )
+    if capture:
+        return subprocess.run(["aws", *args], check=True, text=True, capture_output=True)
+    # Uncaptured aws output (login prompts, kubeconfig updates) goes to
+    # stderr: stdout is reserved for the eval-able AWS_PROFILE export line.
+    return subprocess.run(["aws", *args], check=True, text=True, stdout=sys.stderr)
 
 
 def login(ci_profile: str) -> None:
@@ -227,7 +228,7 @@ def login(ci_profile: str) -> None:
         "sts", "get-caller-identity", "--profile", ci_profile, "--output", "text",
         "--query", "Arn", capture=True,
     ).stdout.strip()
-    print(f"logged in; {ci_profile} resolves to {identity}")
+    print(f"logged in; {ci_profile} resolves to {identity}", file=sys.stderr)
 
 
 def update_kubeconfig(ci_profile: str) -> None:
@@ -255,7 +256,7 @@ def main() -> int:
         choices=["up", "configure", "login", "kubeconfig", "export"],
         help=(
             "up: configure + login + kubeconfig; "
-            "export: print an eval-able AWS_PROFILE export line"
+            "up, login, and export print an eval-able AWS_PROFILE export line"
         ),
     )
     parser.add_argument("--environment", "-e", choices=list(SHORT_ENV_NAMES), required=True)
@@ -288,13 +289,16 @@ def main() -> int:
     if args.command in ("up", "kubeconfig"):
         update_kubeconfig(ci_profile)
 
-    if args.command == "up":
-        print(
-            "\nto point subsequent aws/terraform commands at this environment:\n"
-            f'  eval "$({Path(sys.argv[0])} export --environment {args.environment}'
-            f'{" --read-only" if args.read_only else ""})"\n'
-            "kubectl already works: the kubeconfig embeds the profile."
+    if args.command in ("up", "login"):
+        hint = (
+            "\nexport line follows on stdout; to adopt the profile in the "
+            "current shell,\nrun this command as "
+            f'eval "$({Path(sys.argv[0])} ...)" or copy the line below.'
         )
+        if args.command == "up":
+            hint += "\nkubectl already works: the kubeconfig embeds the profile."
+        print(hint + "\n", file=sys.stderr)
+        print(f"export AWS_PROFILE={ci_profile}")
     return 0
 
 

--- a/scripts/infra_eng_sso.py
+++ b/scripts/infra_eng_sso.py
@@ -49,10 +49,11 @@ AWS_CONFIG_PATH = Path.home() / ".aws" / "config"
 
 SECTION_HEADER_RE = re.compile(r"^\s*\[[^\]]+\]\s*$")
 
-# `aws sso login` needs the AWS access portal URL. The Identity Center console
-# also shows an instance/issuer URL (https://identitycenter.amazonaws.com/
-# ssoins-...); the device flow accepts it but browser sign-in then fails with
-# "We couldn't verify your sign-in credentials", so reject it before writing.
+# The documented sso_start_url value is the AWS access portal URL. The
+# Identity Center console also shows an instance/issuer URL
+# (https://identitycenter.amazonaws.com/ssoins-...); logins with it can work,
+# but it is not the documented start URL and diverges from the profile
+# reference in docs/aws-sso-auth.md, so reject it before persisting.
 PORTAL_URL_RE = re.compile(r"^https://[a-z0-9.-]+\.awsapps\.com/start/?$")
 ACCOUNT_ID_RE = re.compile(r"^\d{12}$")
 
@@ -62,10 +63,7 @@ def validate_sso_start_url(sso_start_url: str) -> None:
         return
     message = f"error: {sso_start_url!r} is not an AWS access portal URL"
     if "identitycenter.amazonaws.com" in sso_start_url:
-        message += (
-            ":\nthis is the Identity Center instance (issuer) URL; browser sign-in"
-            '\nwith it fails with "We couldn\'t verify your sign-in credentials"'
-        )
+        message += ":\nthis is the Identity Center instance (issuer) URL, not the portal URL"
     sys.exit(
         message
         + "\nexpected form: https://<subdomain>.awsapps.com/start"
@@ -206,7 +204,18 @@ def aws(*args: str, capture: bool = False) -> subprocess.CompletedProcess:
 
 
 def login(ci_profile: str) -> None:
-    aws("sso", "login", "--sso-session", SSO_SESSION_NAME)
+    try:
+        aws("sso", "login", "--sso-session", SSO_SESSION_NAME)
+    except subprocess.CalledProcessError as error:
+        sys.exit(
+            f"error: aws sso login exited with status {error.returncode}\n"
+            'if the browser showed "Something doesn\'t compute - We couldn\'t verify\n'
+            'your sign-in credentials", the local config is usually not the problem:\n'
+            "that page comes from stale AWS sign-in state in the browser or from\n"
+            "federating the wrong Google account. Retry in a private window and pick\n"
+            "your Workspace account, or clear cookies for awsapps.com and\n"
+            "signin.aws.amazon.com. See docs/aws-sso-auth.md#troubleshooting."
+        )
     identity = aws(
         "sts", "get-caller-identity", "--profile", ci_profile, "--output", "text",
         "--query", "Arn", capture=True,

--- a/scripts/infra_eng_sso.py
+++ b/scripts/infra_eng_sso.py
@@ -23,8 +23,11 @@ or run the full flow and copy the printed export line:
     scripts/infra_eng_sso.py up --environment staging
 
 First run needs --sso-start-url and --account-id; both are persisted in
-~/.aws/config and read back on later runs. Runs on the standard library
-plus the aws CLI (v2, for sso-session support).
+~/.aws/config and read back on later runs. The start URL must be the AWS
+access portal URL (https://<subdomain>.awsapps.com/start), not the Identity
+Center instance URL (https://identitycenter.amazonaws.com/ssoins-...) also
+shown in the console. Runs on the standard library plus the aws CLI (v2,
+for sso-session support).
 """
 
 from __future__ import annotations
@@ -45,6 +48,30 @@ SHORT_ENV_NAMES = {"development": "dev", "staging": "staging", "production": "pr
 AWS_CONFIG_PATH = Path.home() / ".aws" / "config"
 
 SECTION_HEADER_RE = re.compile(r"^\s*\[[^\]]+\]\s*$")
+
+# `aws sso login` needs the AWS access portal URL. The Identity Center console
+# also shows an instance/issuer URL (https://identitycenter.amazonaws.com/
+# ssoins-...); the device flow accepts it but browser sign-in then fails with
+# "We couldn't verify your sign-in credentials", so reject it before writing.
+PORTAL_URL_RE = re.compile(r"^https://[a-z0-9.-]+\.awsapps\.com/start/?$")
+ACCOUNT_ID_RE = re.compile(r"^\d{12}$")
+
+
+def validate_sso_start_url(sso_start_url: str) -> None:
+    if PORTAL_URL_RE.match(sso_start_url):
+        return
+    message = f"error: {sso_start_url!r} is not an AWS access portal URL"
+    if "identitycenter.amazonaws.com" in sso_start_url:
+        message += (
+            ":\nthis is the Identity Center instance (issuer) URL; browser sign-in"
+            '\nwith it fails with "We couldn\'t verify your sign-in credentials"'
+        )
+    sys.exit(
+        message
+        + "\nexpected form: https://<subdomain>.awsapps.com/start"
+        + "\n(Identity Center console -> Settings -> AWS access portal URL;"
+        + "\nre-run configure with --sso-start-url to replace a persisted value)"
+    )
 
 
 def profile_names(environment: str, read_only: bool) -> tuple[str, str]:
@@ -127,6 +154,9 @@ def configure(environment: str, read_only: bool, sso_start_url: str | None, acco
             f"error: {' and '.join(missing)} required on first run "
             "(persisted in ~/.aws/config afterwards)"
         )
+    validate_sso_start_url(sso_start_url)
+    if not ACCOUNT_ID_RE.match(account_id):
+        sys.exit(f"error: account id must be 12 digits, got {account_id!r}")
 
     sso_profile, ci_profile = profile_names(environment, read_only)
     config_text = AWS_CONFIG_PATH.read_text() if AWS_CONFIG_PATH.exists() else ""
@@ -218,7 +248,13 @@ def main() -> int:
         action="store_true",
         help="use the InfraEng<Env>ReadOnly permission set and read-only CI role",
     )
-    parser.add_argument("--sso-start-url", help="Identity Center start URL (first run only)")
+    parser.add_argument(
+        "--sso-start-url",
+        help=(
+            "AWS access portal URL, https://<subdomain>.awsapps.com/start — "
+            "not the identitycenter.amazonaws.com instance URL (first run only)"
+        ),
+    )
     parser.add_argument("--account-id", help="AWS account id (first run only)")
     args = parser.parse_args()
 

--- a/scripts/infra_eng_sso.py
+++ b/scripts/infra_eng_sso.py
@@ -24,10 +24,11 @@ or run the full flow and copy the printed export line:
 
 First run needs --sso-start-url and --account-id; both are persisted in
 ~/.aws/config and read back on later runs. The start URL must be the AWS
-access portal URL (https://<subdomain>.awsapps.com/start), not the Identity
-Center instance URL (https://identitycenter.amazonaws.com/ssoins-...) also
-shown in the console. Runs on the standard library plus the aws CLI (v2,
-for sso-session support).
+access portal URL — https://<subdomain>.awsapps.com/start or the newer
+https://ssoins-<id>.portal.<region>.app.aws — not the Identity Center
+instance URL (https://identitycenter.amazonaws.com/ssoins-...) also shown
+in the console. Runs on the standard library plus the aws CLI (v2, for
+sso-session support).
 """
 
 from __future__ import annotations
@@ -49,17 +50,22 @@ AWS_CONFIG_PATH = Path.home() / ".aws" / "config"
 
 SECTION_HEADER_RE = re.compile(r"^\s*\[[^\]]+\]\s*$")
 
-# The documented sso_start_url value is the AWS access portal URL. The
-# Identity Center console also shows an instance/issuer URL
+# The documented sso_start_url value is the AWS access portal URL, in either
+# the legacy form (https://<subdomain>.awsapps.com/start) or the newer form
+# (https://ssoins-<id>.portal.<region>.app.aws). The Identity Center console
+# also shows an instance/issuer URL
 # (https://identitycenter.amazonaws.com/ssoins-...); logins with it can work,
 # but it is not the documented start URL and diverges from the profile
 # reference in docs/aws-sso-auth.md, so reject it before persisting.
-PORTAL_URL_RE = re.compile(r"^https://[a-z0-9.-]+\.awsapps\.com/start/?$")
+PORTAL_URL_RES = (
+    re.compile(r"^https://[a-z0-9.-]+\.awsapps\.com/start/?$"),
+    re.compile(r"^https://ssoins-[a-z0-9]+\.portal\.[a-z0-9-]+\.app\.aws/?$"),
+)
 ACCOUNT_ID_RE = re.compile(r"^\d{12}$")
 
 
 def validate_sso_start_url(sso_start_url: str) -> None:
-    if PORTAL_URL_RE.match(sso_start_url):
+    if any(pattern.match(sso_start_url) for pattern in PORTAL_URL_RES):
         return
     message = f"error: {sso_start_url!r} is not an AWS access portal URL"
     if "identitycenter.amazonaws.com" in sso_start_url:
@@ -67,6 +73,7 @@ def validate_sso_start_url(sso_start_url: str) -> None:
     sys.exit(
         message
         + "\nexpected form: https://<subdomain>.awsapps.com/start"
+        + "\n            or https://ssoins-<id>.portal.<region>.app.aws"
         + "\n(Identity Center console -> Settings -> AWS access portal URL;"
         + "\nre-run configure with --sso-start-url to replace a persisted value)"
     )
@@ -260,8 +267,9 @@ def main() -> int:
     parser.add_argument(
         "--sso-start-url",
         help=(
-            "AWS access portal URL, https://<subdomain>.awsapps.com/start — "
-            "not the identitycenter.amazonaws.com instance URL (first run only)"
+            "AWS access portal URL, https://<subdomain>.awsapps.com/start or "
+            "https://ssoins-<id>.portal.<region>.app.aws — not the "
+            "identitycenter.amazonaws.com instance URL (first run only)"
         ),
     )
     parser.add_argument("--account-id", help="AWS account id (first run only)")


### PR DESCRIPTION
## Problem

On first run `scripts/infra_eng_sso.py` accepts any `--sso-start-url` and persists it to `~/.aws/config`, and a failed `aws sso login` surfaces as a raw traceback. Both bit us on the first real staging read-only run: the Identity Center **instance/issuer URL** (`https://identitycenter.amazonaws.com/ssoins-...`) was persisted instead of the **access portal URL** (`https://<subdomain>.awsapps.com/start`), and the browser flow died with *"Something doesn't compute — We couldn't verify your sign-in credentials"* with nothing pointing at a cause.

Forensics on the second failure (same error page **after** the start URL was corrected, with a freshly registered OIDC client) showed the error page is produced by the browser side of the flow, not the config: probing the `/authorize` endpoint directly gives a healthy sign-in redirect for every client involved, including the failing run's client, and cached tokens show instance-URL logins had succeeded earlier the same day. Root cause of the error page: stale AWS sign-in session state in the browser, or Google federating the wrong account.

## Fix

- Validate the start URL (flag or persisted) is the portal-URL form before writing config — the instance URL is undocumented as a start URL and diverges from `docs/aws-sso-auth.md`. Targeted error points at Identity Center console → Settings → AWS access portal URL.
- Validate `--account-id` is 12 digits.
- `login()` now catches a failed `aws sso login` and prints actionable guidance (retry in a private window with the Workspace account; clear `awsapps.com` / `signin.aws.amazon.com` cookies) instead of a traceback.
- New Troubleshooting section in `docs/aws-sso-auth.md` covering this exact error page.

## Testing

- `configure` with an instance URL exits 1 with the targeted message; non-12-digit account id likewise.
- `configure -e staging --read-only` with valid persisted values still writes the profile chain.
- `/authorize` probes (fresh clients registered with portal vs instance issuer URLs, plus the cached working/failing clients) all return healthy sign-in redirects, supporting the browser-state diagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)