### PR TITLE
Bump staging EKS cluster to Kubernetes 1.36

### DIFF
--- a/terraform/env/staging/aws/us-west-1/base-cluster-layer/terraform.tfvars
+++ b/terraform/env/staging/aws/us-west-1/base-cluster-layer/terraform.tfvars
@@ -3,5 +3,5 @@ ci_read_only_trusted_principal_arns = []
 ci_trusted_principal_arns           = []
 enable_sso_infra_eng                = true
 environment_name                    = "staging"
-kubernetes_cluster_version          = "1.35"
+kubernetes_cluster_version          = "1.36"
 project_tag                         = "automation-calculator"

--- a/version_dates/eks_version_dates.json
+++ b/version_dates/eks_version_dates.json
@@ -17,6 +17,12 @@
       "eks_ga_date": "2026-01-27",
       "standard_support_end": "2027-03-27",
       "extended_support_end": "2028-03-27"
+    },
+    {
+      "version": "1.36",
+      "eks_ga_date": "2026-06-02",
+      "standard_support_end": "2027-08-02",
+      "extended_support_end": "2028-08-02"
     }
   ]
 }


### PR DESCRIPTION
## What

- `terraform/env/staging/aws/us-west-1/base-cluster-layer/terraform.tfvars`: `kubernetes_cluster_version` 1.35 → 1.36
- `version_dates/eks_version_dates.json`: add EKS 1.36 entry (GA 2026-06-02, standard support ends 2027-08-02, extended support ends 2028-08-02)

## Breaking-change audit for Kubernetes 1.36

Checked every EKS 1.36 release-note item against this repo; **no code fixes required**:

| 1.36 change | Impact here |
|---|---|
| `gitRepo` volume removed | Not used anywhere in the Helm chart or Terraform |
| Strict IP/CIDR validation (leading zeros, non-canonical CIDRs rejected on K8s API objects) | No IP/CIDR literals in any Kubernetes manifest; the CIDRs in `terraform/modules/aws/networking` are VPC resources, not K8s API fields |
| Service `.spec.externalIPs` deprecated | Chart's Service does not set `externalIPs` |
| IPVS kube-proxy mode removed | EKS default (iptables) is used; no kube-proxy customization in this repo |
| containerd 1.x unsupported | Node groups use `AL2023_x86_64_STANDARD` with no pinned `ami_id`, so the 1.36 EKS-optimized AMI (containerd 2.x) is picked up automatically |
| SELinux volume-labeling GA | AL2023 EKS nodes do not run SELinux enforcing; no pod-level SELinux config in the chart |

Add-on compatibility (no bumps needed for this upgrade):
- aws-load-balancer-controller chart 1.4.6 (controller v2.4.x) — requires K8s ≥1.19, uses stable APIs + its own CRDs; compatible. It is old, though — worth a separate upgrade PR at some point.
- external-dns (Bitnami 9.0.3) and metrics-server (3.8.3) — stable APIs only; compatible.
- coredns / kube-proxy / vpc-cni are not Terraform-managed EKS add-ons in this repo.

## Apply / rollout notes

1. Apply `base-cluster-layer` for staging; control plane upgrades in place, then the managed node group rolls onto the 1.36 AL2023 AMI.
2. After the control-plane upgrade, update the default add-ons (kube-proxy, coredns, vpc-cni) to their 1.36-compatible versions via console/CLI, since they are not managed by Terraform.
3. EKS upgrades are one-way — no rollback to 1.35 after apply.

Production follow-up PR bumps prod after staging soaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)