### PR TITLE
Bump production EKS cluster to Kubernetes 1.36

### DIFF
--- a/terraform/env/production/aws/us-west-1/base-cluster-layer/terraform.tfvars
+++ b/terraform/env/production/aws/us-west-1/base-cluster-layer/terraform.tfvars
@@ -3,5 +3,5 @@ ci_read_only_trusted_principal_arns = []
 ci_trusted_principal_arns           = []
 enable_sso_infra_eng                = true
 environment_name                    = "production"
-kubernetes_cluster_version          = "1.35"
+kubernetes_cluster_version          = "1.36"
 project_tag                         = "automation-calculator"


### PR DESCRIPTION
## What

- `terraform/env/production/aws/us-west-1/base-cluster-layer/terraform.tfvars`: `kubernetes_cluster_version` 1.35 → 1.36

Companion to #310 (staging bump + EKS 1.36 support dates). **Merge/apply this only after the staging 1.36 upgrade has soaked.**

## Breaking-change audit for Kubernetes 1.36

Full audit in #310 — no code fixes required. Summary: no `gitRepo` volumes, no K8s-side IP/CIDR literals affected by strict validation, no `externalIPs`, no IPVS kube-proxy config, and `AL2023_x86_64_STANDARD` with unpinned `ami_id` picks up the containerd 2.x AMI automatically. Pinned add-ons (aws-load-balancer-controller 1.4.6, external-dns 9.0.3, metrics-server 3.8.3) remain compatible.

## Apply / rollout notes

1. Apply `base-cluster-layer` for production; control plane upgrades in place, then the managed node group rolls onto the 1.36 AL2023 AMI.
2. After the control-plane upgrade, update the default add-ons (kube-proxy, coredns, vpc-cni) to their 1.36-compatible versions via console/CLI, since they are not managed by Terraform.
3. EKS upgrades are one-way — no rollback to 1.35 after apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)