### PR TITLE
Migrate bump PR script from hub to gh

### DIFF
--- a/scripts/bump_app_docker_image_version_branch.sh
+++ b/scripts/bump_app_docker_image_version_branch.sh
@@ -36,7 +36,7 @@ git commit -m "Bump app docker image version to ${NEW_VERSION}"
 git push origin bump-app-docker-image-version-${NEW_VERSION}
 
 #make PR
-hub pull-request -m "Bump app docker image version to ${NEW_VERSION}"
+gh pr create --title "Bump app docker image version to ${NEW_VERSION}" --body ""
 
 #show PR
-hub pr show
+gh pr view --web


### PR DESCRIPTION
watch_app_docker_image_versions.py delegates PR creation to scripts/bump_app_docker_image_version_branch.sh, which still used the hub CLI. hub's token lacks PR-write access on this repo, so the final step of the watch-and-bump flow fails. This switches the two hub calls to their gh equivalents:

- `hub pull-request -m "..."` → `gh pr create --title "..." --body ""`
- `hub pr show` → `gh pr view --web`

🤖 Generated with [Claude Code](https://claude.com/claude-code)