### PR TITLE
Fix external-dns ImagePullBackOff by switching to bitnamilegacy image

### DIFF
--- a/terraform/modules/aws/cluster-addons-layer/main.tf
+++ b/terraform/modules/aws/cluster-addons-layer/main.tf
@@ -99,9 +99,21 @@ resource "helm_release" "external-dns" {
     value = "public"
   }
 
+  # Bitnami purged versioned tags from public.ecr.aws/bitnami; bitnamilegacy
+  # on Docker Hub is the frozen archive of the same images.
   set {
     name  = "image.registry"
-    value = "public.ecr.aws"
+    value = "docker.io"
+  }
+
+  set {
+    name  = "image.repository"
+    value = "bitnamilegacy/external-dns"
+  }
+
+  set {
+    name  = "image.tag"
+    value = "0.18.0-debian-12-r4"
   }
 
   set {


### PR DESCRIPTION
## Problem

During the staging EKS 1.36 upgrade (#310), the node group rollout replaced the worker node and `external-dns` went into `ImagePullBackOff`:

```
Failed to pull image "public.ecr.aws/bitnami/external-dns:0.18.0-debian-12-r4": not found
```

The `bitnami/external-dns` repository no longer exists on `public.ecr.aws` — Bitnami purged versioned images from its free catalog. The pod only ran before because the old node had the image cached.

**Production is exposed to the same failure**: same module config, and its next node replacement will be unable to pull the image.

## Fix

Point the chart at `docker.io/bitnamilegacy/external-dns` (Bitnami's frozen archive of the same images — verified the manifest for `0.18.0-debian-12-r4` returns 200) and pin the exact tag that was previously running. The chart already sets `global.security.allowInsecureImages=true`, which the Bitnami chart requires for non-default image repositories.

## Verification plan

After merge, apply `cluster-addons-layer` for staging and confirm the external-dns pod reaches Running; then apply production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)