### PR TITLE
Add read-only CI role EKS access entry to production

### DIFF
--- a/terraform/env/production/aws/us-west-1/base-cluster-layer/main.tf
+++ b/terraform/env/production/aws/us-west-1/base-cluster-layer/main.tf
@@ -54,15 +54,26 @@ module "eks_cluster" {
     min_size     = 1
   }
 
-  # Grants the CI Terraform role kubectl/Helm access to the cluster API.
-  # Human InfraEng access flows through the same role: SSO users assume it
-  # (see ci_iam_role trust policy), so no per-user entries are needed.
+  # Grants the CI Terraform roles kubectl/Helm access to the cluster API.
+  # Human InfraEng access flows through the same roles: SSO users assume
+  # them (see ci_iam_role trust policies), so no per-user entries are
+  # needed. The read-only role gets the view policy, matching its
+  # plan-and-inspect-only IAM permissions.
   access_entries = {
     ci_terraform = {
       principal_arn = module.ci_iam_role.role_arn
       policy_associations = {
         cluster_admin = {
           policy_arn   = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+          access_scope = { type = "cluster" }
+        }
+      }
+    }
+    ci_terraform_read_only = {
+      principal_arn = module.ci_iam_role.read_only_role_arn
+      policy_associations = {
+        view = {
+          policy_arn   = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSViewPolicy"
           access_scope = { type = "cluster" }
         }
       }


### PR DESCRIPTION
## Problem

Read-only prod access (`scripts/infra_eng_sso.py up -e production --read-only`) authenticates fine on the AWS side — the `ac_ci_terraform_production_read_only` role assumes correctly — but every kubectl/kubens call against the prod cluster fails with 401 ("the server has asked for the client to provide credentials").

`aws eks list-access-entries --cluster-name ac_app_production` confirms the cluster only has access entries for `ac_ci_terraform_production` (read-write), the EKS service role, the node group role, and the legacy `automation-calculator` IAM user. The read-only role was never granted Kubernetes API access.

## Fix

Mirror staging's `ci_terraform_read_only` access entry in production's base-cluster-layer: grant `module.ci_iam_role.read_only_role_arn` the `AmazonEKSViewPolicy` at cluster scope. Comment updated to staging's wording.

Staging and development already have this entry; production was the only environment missing it.

## Apply

Requires a Terraform Cloud apply of the production `base-cluster-layer` workspace after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)