### PR TITLE
Replace Bitnami external-dns chart with official kubernetes-sigs chart

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,7 +102,7 @@ Lock files (`.terraform.lock.hcl`) are committed in every module and env config 
 
 ## External-DNS Helm Registry
 
-External-DNS uses the Bitnami OCI registry (`oci://registry-1.docker.io/bitnamicharts`), not the legacy HTTP repo. Use `chart = "external-dns"` with `repository = "oci://registry-1.docker.io/bitnamicharts"` in any `helm_release` resource.
+External-DNS uses the official kubernetes-sigs chart (`repository = "https://kubernetes-sigs.github.io/external-dns/"`, `chart = "external-dns"`), not Bitnami. Bitnami charts/images are unmaintained (versioned tags were purged from `public.ecr.aws/bitnami`; only the frozen `bitnamilegacy` archive remains) — do not reintroduce them. Note the official chart's value names differ from Bitnami's: `provider.name` (not `provider`), and AWS zone filtering goes through `extraArgs` (e.g. `--aws-zone-type=public`) rather than `aws.zoneType`.
 
 ## Pull Requests
 

--- a/terraform/modules/aws/cluster-addons-layer/main.tf
+++ b/terraform/modules/aws/cluster-addons-layer/main.tf
@@ -84,43 +84,24 @@ resource "helm_release" "external-dns" {
     kubernetes_service_account_v1.external_dns_service_account
   ]
   name       = "external-dns"
-  repository = "oci://registry-1.docker.io/bitnamicharts"
+  repository = "https://kubernetes-sigs.github.io/external-dns/"
   chart      = "external-dns"
-  version    = "9.0.3"
+  version    = "1.21.1"
   namespace  = "kube-system"
 
   set {
-    name  = "provider"
+    name  = "provider.name"
     value = "aws"
   }
 
   set {
-    name  = "aws.zoneType"
-    value = "public"
+    name  = "extraArgs[0]"
+    value = "--aws-zone-type=public"
   }
 
-  # Bitnami purged versioned tags from public.ecr.aws/bitnami; bitnamilegacy
-  # on Docker Hub is the frozen archive of the same images.
-  set {
-    name  = "image.registry"
-    value = "docker.io"
-  }
-
-  set {
-    name  = "image.repository"
-    value = "bitnamilegacy/external-dns"
-  }
-
-  set {
-    name  = "image.tag"
-    value = "0.18.0-debian-12-r4"
-  }
-
-  set {
-    name  = "global.security.allowInsecureImages"
-    value = "true"
-  }
-
+  # Chart defaults (policy=upsert-only, txt registry, owner id "default")
+  # match the previous Bitnami deployment, so existing Route 53 TXT
+  # ownership records stay valid across the migration.
   set {
     name  = "serviceAccount.create"
     value = "false"


### PR DESCRIPTION
## Why

Bitnami purged versioned image tags from its public registries in 2025, which forced us to pin external-dns to the frozen `bitnamilegacy/external-dns:0.18.0-debian-12-r4` archive with `global.security.allowInsecureImages=true`. That image will never receive another update, so this was a dead end, not a fix.

## What

Swap `helm_release.external-dns` in `terraform/modules/aws/cluster-addons-layer` from the Bitnami chart (9.0.3) to the official kubernetes-sigs chart (**1.21.1**, app **v0.21.0**, image `registry.k8s.io/external-dns/external-dns`). All three environments consume this module, so they all pick up the change.

Value mapping (Bitnami → official):

| Bitnami | Official |
|---|---|
| `provider=aws` | `provider.name=aws` |
| `aws.zoneType=public` | `extraArgs[0]=--aws-zone-type=public` |
| `image.*` + `allowInsecureImages` overrides | dropped (chart default is registry.k8s.io) |
| `serviceAccount.create=false` / `.name=external-dns` | unchanged |

Also updated the CLAUDE.md External-DNS registry convention to point at the official chart.

## Migration safety

- **TXT ownership records stay valid**: both charts default to `policy=upsert-only`, the `txt` registry, and owner id `default`, so external-dns keeps ownership of the existing Route 53 records (relevant given the July 2026 orphaned-TXT incident in prod).
- **In-place Helm upgrade works**: both charts render the Deployment name `external-dns` with identical selector labels (`app.kubernetes.io/name` + `app.kubernetes.io/instance`), so the upgrade avoids the immutable-selector error. If TFC still reports a conflict on apply, the fallback is `kubectl -n kube-system delete deployment external-dns` and re-apply — safe because upsert-only never deletes DNS records.
- The pre-existing IRSA role and `external-dns` service account are untouched.

`terraform fmt -check` and `terraform validate` pass on the module. Suggest applying to development first, confirming records reconcile in the logs, then staging/prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)